### PR TITLE
Remove the duplicate bookfuncs.js script tag in built page's head

### DIFF
--- a/runestone/datafile/__init__.py
+++ b/runestone/datafile/__init__.py
@@ -23,7 +23,6 @@ from docutils.parsers.rst import Directive
 
 def setup(app):
     app.add_directive('datafile',DataFile)
-    app.add_javascript('bookfuncs.js')
     app.add_javascript('skulpt.min.js')
     app.add_javascript('skulpt-stdlib.js')
 


### PR DESCRIPTION
the bookfuncs.js script was getting added to build page's html <head> twice, and that was causing a lot of javascript to be executed twice unnecessarily.

It was being added in two places: activecode/activecode.py's setup() and datafile/__init__.py's setup(). Removed it from the later.