### PR TITLE
Adding jQuery UI Touch-Punch so that mobile devices work with Parsons

### DIFF
--- a/runestone/parsons/js/lib/jquery.ui.touch-punch.min.js
+++ b/runestone/parsons/js/lib/jquery.ui.touch-punch.min.js
@@ -1,0 +1,11 @@
+/*!
+ * jQuery UI Touch Punch 0.2.3
+ *
+ * Copyright 2011–2014, Dave Furfero
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Depends:
+ *  jquery.ui.widget.js
+ *  jquery.ui.mouse.js
+ */
+!function(a){function f(a,b){if(!(a.originalEvent.touches.length>1)){a.preventDefault();var c=a.originalEvent.changedTouches[0],d=document.createEvent("MouseEvents");d.initMouseEvent(b,!0,!0,window,1,c.screenX,c.screenY,c.clientX,c.clientY,!1,!1,!1,!1,0,null),a.target.dispatchEvent(d)}}if(a.support.touch="ontouchend"in document,a.support.touch){var e,b=a.ui.mouse.prototype,c=b._mouseInit,d=b._mouseDestroy;b._touchStart=function(a){var b=this;!e&&b._mouseCapture(a.originalEvent.changedTouches[0])&&(e=!0,b._touchMoved=!1,f(a,"mouseover"),f(a,"mousemove"),f(a,"mousedown"))},b._touchMove=function(a){e&&(this._touchMoved=!0,f(a,"mousemove"))},b._touchEnd=function(a){e&&(f(a,"mouseup"),f(a,"mouseout"),this._touchMoved||f(a,"click"),e=!1)},b._mouseInit=function(){var b=this;b.element.bind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),c.call(b)},b._mouseDestroy=function(){var b=this;b.element.unbind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),d.call(b)}}}(jQuery);

--- a/runestone/parsons/parsons.py
+++ b/runestone/parsons/parsons.py
@@ -33,6 +33,7 @@ def setup(app):
     # jquery to their original versions
     app.add_javascript('lib/jquery.min.js')
     app.add_javascript('lib/jquery-ui.min.js')
+    app.add_javascript('lib/jquery.ui.touch-punch.min.js')
     app.add_javascript('lib/prettify.js')
     app.add_javascript('lib/underscore-min.js')
     app.add_javascript('lib/lis.js')


### PR DESCRIPTION
For js-parsons [examples](http://js-parsons.github.io) to work on mobile they added [jQuery UI Touch Punch](http://touchpunch.furf.com) in order for their examples to work on mobile ([1](https://github.com/js-parsons/js-parsons/commit/deeffdf08c7b77981a557707bbcfed26a9ceab2e), [2](https://github.com/js-parsons/js-parsons/issues/22)).

![withtouchpunch](https://cloud.githubusercontent.com/assets/1296209/11216713/bc087190-8d1a-11e5-800a-7aa23b444011.gif)

Because I know some of my students would much rather try to do their work on their phones rather than their iPads:

![withtouchpunchiphone](https://cloud.githubusercontent.com/assets/1296209/11216721/c05eae12-8d1a-11e5-9b5f-56243cbb6911.gif)

Works on:
- Safari on iPad iOS 9.1 (Touch)
- Safari on iPhone iOS 9.1 (Touch)
- Safari 9.0.1 on Mac OS 10.11.1 (Mouse)
- Chrome 46 on Mac OS 10.11.1 (Mouse)
- Chrome 46 on Windows 10 with 2 Point Touch (Touch and Mouse)
- And a Kindle Fire of unknown age and OS version

Doesn't work on Microsoft Edge on Windows 10 with 2 Point Touch, but it doesn't break mouse interaction.

Also unsure how Windows 10 with Pen support works with it as we are utterly incapable of hanging on to stylus pens around here.

Closes #105 