### PR TITLE
MC compare button fix

### DIFF
--- a/runestone/assess/js/mchoice.js
+++ b/runestone/assess/js/mchoice.js
@@ -313,7 +313,9 @@ MultipleChoice.prototype.restoreMultipleSelect = function () {
                         $(this.optionArray[b].input).attr("checked", "true");
                     }
                 }
-                this.enableMCComparison();
+                if (this.useRunestoneServices) {
+                    this.enableMCComparison();
+                }
             } // end for
         } // end if
     } // end if len > 0


### PR DESCRIPTION
This is another case where enableMCComparision() fails unless runestone services are being used, so it must be enclosed in the if block, or there will be errors when someone who isn't using runestone services tries to load previous answers from local storage on page load.