### PR TITLE
Remove error div when running JavaScript.

### DIFF
--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -727,7 +727,8 @@ JSActiveCode.prototype.runProg = function() {
         if (!str) str="";
         _this.output.innerHTML += _this.outputfun(str)+"<br />";
             };
-
+    
+    $(this.eContainer).remove();
     $(this.output).text('');
     $(this.codeDiv).switchClass("col-md-12","col-md-6",{duration:500,queue:false});
     $(this.outDiv).show({duration:700,queue:false});


### PR DESCRIPTION
If you have a syntax error in JavaScript, the error/description/fix div appears when you click Run. If you then correct the error and click Run again, the error div remains on the screen. This pull request makes the error div disappear when you run code again.