### PR TITLE
Fixing indentation bug in parsons problems

### DIFF
--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -820,8 +820,12 @@
       // Consecutive lines to be dragged as a single block of code have strings "\\n" to
       // represent newlines => replace them with actual new line characters "\n"
       //codestring = codestring.replace(/\\n\s+/g,"\\n"); // remove leading spaced if more than one line in a code block - added in below to not change the codestring
-      this.code = code.replace(trimRegexp, "$1").replace(/\\n\s+/g,"\\n").replace(/\\n+/g,"\n");
+      this.code = code.replace(trimRegexp, "$1").replace(/\\n+/g,"\n");
       this.indent = codestring.length - codestring.replace(/^\s+/, "").length;
+      alert("Code");
+      alert(this.code);
+      alert("Codestring");
+      alert(codestring);
     }
   };
   ParsonsCodeline.prototype.elem = function() {

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -820,9 +820,46 @@
       // Consecutive lines to be dragged as a single block of code have strings "\\n" to
       // represent newlines => replace them with actual new line characters "\n"
       //codestring = codestring.replace(/\\n\s+/g,"\\n"); // remove leading spaced if more than one line in a code block - added in below to not change the codestring
-      this.code = code.replace(trimRegexp, "$1").replace(/\\n+/g,"\n");
       this.indent = codestring.length - codestring.replace(/^\s+/, "").length;
 
+      var linelist = [];
+      var line = "";
+
+      for (char in code) {
+
+        if (code[char] == 'n') {
+          if (code[char-1] == '\\') {
+            line = line + 'n';
+            linelist.push(line);
+            line = "";
+          } else {
+
+            line = line + code[char];
+          }
+
+         } else {
+
+          line = line + code[char];
+        }
+      }
+      linelist.push(line);
+
+      var indentFlag = false;
+      for (lineindex in linelist) {
+        var line = linelist[lineindex];
+        var numSpaces = line.length - line.replace(/^\s+/, "").length;
+        if (numSpaces != this.indent)  {
+          indentFlag = true;
+        }
+      }
+
+      if (indentFlag) {
+        //Only strip leading white space on the first line of the code block
+        this.code = code.replace(trimRegexp, "$1").replace(/\\n+/g,"\n");
+      } else {
+        //strip all leading white space on each line of the code block
+        this.code = code.replace(trimRegexp, "$1").replace(/\\n\s+/g,"\\n").replace(/\\n+/g,"\n");
+      }
     }
   };
   ParsonsCodeline.prototype.elem = function() {

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -824,28 +824,28 @@
       var linelist = [];
       var line = "";
 
-      for (char in code) {
+      for (i=0; i<code.length; i++) {
 
-        if (code[char] == 'n') {
-          if (code[char-1] == '\\') {
+        if (code.charAt(i) == 'n') {
+          if (code.charAt(i-1) == '\\') {
             line = line + 'n';
             linelist.push(line);
             line = "";
           } else {
 
-            line = line + code[char];
+            line = line + code.charAt(i);
           }
 
          } else {
 
-          line = line + code[char];
+          line = line + code.charAt(i);
         }
       }
       linelist.push(line);
 
       var indentFlag = false;
-      for (lineindex in linelist) {
-        var line = linelist[lineindex];
+      for (i=0;i<linelist.length;i++) {
+        var line = linelist[i];
         var numSpaces = line.length - line.replace(/^\s+/, "").length;
         if (numSpaces != this.indent)  {
           indentFlag = true;
@@ -855,8 +855,8 @@
       if (indentFlag) {
         if (this.indent > 0) {
           code = "";
-          for (lineindex in linelist) {
-            code = code + linelist[lineindex].slice(this.indent);
+          for (i=0;i<linelist.length;i++) {
+            code = code + linelist[i].slice(this.indent);
           }
         }
 

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -821,7 +821,6 @@
       // represent newlines => replace them with actual new line characters "\n"
       //codestring = codestring.replace(/\\n\s+/g,"\\n"); // remove leading spaced if more than one line in a code block - added in below to not change the codestring
       this.indent = codestring.length - codestring.replace(/^\s+/, "").length;
-
       var linelist = [];
       var line = "";
 
@@ -854,8 +853,16 @@
       }
 
       if (indentFlag) {
-        //Only strip leading white space on the first line of the code block
+        if (this.indent > 0) {
+          code = "";
+          for (lineindex in linelist) {
+            code = code + linelist[lineindex].slice(this.indent);
+          }
+        }
+
         this.code = code.replace(trimRegexp, "$1").replace(/\\n+/g,"\n");
+
+
       } else {
         //strip all leading white space on each line of the code block
         this.code = code.replace(trimRegexp, "$1").replace(/\\n\s+/g,"\\n").replace(/\\n+/g,"\n");

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -822,10 +822,7 @@
       //codestring = codestring.replace(/\\n\s+/g,"\\n"); // remove leading spaced if more than one line in a code block - added in below to not change the codestring
       this.code = code.replace(trimRegexp, "$1").replace(/\\n+/g,"\n");
       this.indent = codestring.length - codestring.replace(/^\s+/, "").length;
-      alert("Code");
-      alert(this.code);
-      alert("Codestring");
-      alert(codestring);
+
     }
   };
   ParsonsCodeline.prototype.elem = function() {


### PR DESCRIPTION
Split each codeblock into separate lines, storing them in an array for each codeblock (maintaining any leading spaces that were already there). We then checked to see if all the lines had the same indentation, and if they don't, we will keep the original spacing. Otherwise, we remove all the leading spaces to make it look uniform.