### PR TITLE
Multiple choice feedback optional

### DIFF
--- a/runestone/assess/multiplechoice.py
+++ b/runestone/assess/multiplechoice.py
@@ -60,7 +60,7 @@ def depart_mc_node(self,node):
             node.mc_options['alabel'] = label
             node.mc_options['atext'] = node.mc_options[k]
             currFeedback = "feedback_" + label
-            node.mc_options['feedtext'] = node.mc_options[currFeedback]
+            node.mc_options['feedtext'] = node.mc_options.get(currFeedback,"") #node.mc_options[currFeedback]
             if label in node.mc_options['correct']:
                 node.mc_options["is_correct"] = "data-correct"
             else:

--- a/runestone/usageAssignment/__init__.py
+++ b/runestone/usageAssignment/__init__.py
@@ -46,19 +46,24 @@ class usageAssignmentNode(nodes.General, nodes.Element):
 # in html, self is sphinx.writers.html.SmartyPantsHTMLTranslator
 # The node that is passed as a parameter is an instance of our node class.
 def visit_ua_node(self,node):
-    course_name = node.ua_content['course_name']
-    s = ""
-    for d in node.ua_content['chapter_data']:
-        ch_name, sub_chs = d['ch'], d['sub_chs']
-        s += '<div class="panel-heading">'
-        s += ch_name
-        s += '<ul class="list-group">'
-        for sub_ch_name in sub_chs:
-            s += '<li class="simple">'
-            s += '<a href = "/runestone/static/%s/%s/%s.html">%s</a>' % (course_name, ch_name, sub_ch_name, sub_ch_name)
-            s += '</li>'
-        s += '</ul>'
-        s += '</div>'
+    try:
+        course_name = node.ua_content['course_name']
+
+        s = ""
+        for d in node.ua_content['chapter_data']:
+            ch_name, sub_chs = d['ch'], d['sub_chs']
+            s += '<div class="panel-heading">'
+            s += ch_name
+            s += '<ul class="list-group">'
+            for sub_ch_name in sub_chs:
+                s += '<li class="simple">'
+                s += '<a href = "/runestone/static/%s/%s/%s.html">%s</a>' % (course_name, ch_name, sub_ch_name, sub_ch_name)
+                s += '</li>'
+            s += '</ul>'
+            s += '</div>'
+    except:
+            # course_name = "pip2" # TODO is this a good exception?
+        s = ""
 
     # is this needed??
     s = s.replace("u'","'")  # hack:  there must be a better way to include the list and avoid unicode strings
@@ -158,6 +163,7 @@ class usageAssignment(Directive):
             print("  2. unable to connect to the database using dburl")
             print()
             print("This should only affect the grading interface. Everything else should be fine.")
+            return [usageAssignmentNode(self.options)]
 
 
         # create a Session


### PR DESCRIPTION
This should make feedback, e.g. ```:feedback_a:```, etc, optional for multiple choice problems, where it did not parse correctly before.