### PR TITLE
Listeners should be correctly attached to timed elements now

### DIFF
--- a/runestone/assess/js/timed.js
+++ b/runestone/assess/js/timed.js
@@ -65,7 +65,6 @@ Timed.prototype.init = function (opts) {
     this.incorrectStr = "";
     this.skippedStr = "";
     this.skipped = 0;
-    this.hasRenderedFirstQuestion = false;
 
     this.currentQuestionIndex = 0;   // Which question is currently displaying on the page
     this.renderedQuestionArray = []; // list of all problems
@@ -344,12 +343,8 @@ Timed.prototype.renderTimedQuestion = function () {
     // If the timed component has listeners, those might need to be reinitialized
     // This flag will only be set in the elements that need it--it will be undefined in the others and thus evaluate to false
     if (this.renderedQuestionArray[this.currentQuestionIndex].needsReinitialization) {
-        // if this is the first time we're rendering the first question, nothing should be reinitialized
-        if (this.currentQuestionIndex !== 0 || this.hasRenderedFirstQuestion) {
-            this.renderedQuestionArray[this.currentQuestionIndex].reinitializeListeners();
-        }
+        this.renderedQuestionArray[this.currentQuestionIndex].reinitializeListeners();
     }
-    this.hasRenderedFirstQuestion = true;
 };
 
 


### PR DESCRIPTION
This fixes a bug introduced in a previous PR that caused the first element in a timed directive to not have its button listeners attached.