### PR TITLE
when building the book, populate/update the questions table.

### DIFF
--- a/runestone/activecode/activecode.py
+++ b/runestone/activecode/activecode.py
@@ -22,6 +22,7 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
 from .textfield import *
 from sqlalchemy import create_engine, Table, MetaData, select, delete
+from runestone.server.componentdb import addQuestionToDB
 
 try:
     from html import escape  # py3
@@ -158,6 +159,9 @@ class ActiveCode(Directive):
     }
 
     def run(self):
+
+        addQuestionToDB(self)
+
         env = self.state.document.settings.env
         # keep track of how many activecodes we have.... could be used to automatically make a unique id for them.
         if not hasattr(env, 'activecodecounter'):

--- a/runestone/assess/fitb.py
+++ b/runestone/assess/fitb.py
@@ -21,6 +21,7 @@ from docutils.parsers.rst import Directive
 from .assessbase import *
 import json
 import random
+from runestone.server.componentdb import addQuestionToDB
 
 
 
@@ -100,6 +101,7 @@ class FillInTheBlank(Directive):
         </p>
             '''
 
+        addQuestionToDB(self)
 
         self.options['divid'] = self.arguments[0]
 

--- a/runestone/assess/multiplechoice.py
+++ b/runestone/assess/multiplechoice.py
@@ -21,6 +21,7 @@ from docutils.parsers.rst import Directive
 from .assessbase import *
 import json
 import random
+from runestone.server.componentdb import addQuestionToDB
 
 
 class MChoiceNode(nodes.General, nodes.Element):
@@ -154,7 +155,7 @@ class MChoice(Assessment):
 
             </ul>
             '''
-
+        addQuestionToDB(self)
         super(MChoice,self).run()
 
 

--- a/runestone/clickableArea/clickable.py
+++ b/runestone/clickableArea/clickable.py
@@ -19,6 +19,7 @@ __author__ = 'isaiahmayerchak'
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
+from runestone.server.componentdb import addQuestionToDB
 
 def setup(app):
     app.add_directive('clickablearea',ClickableArea)
@@ -115,6 +116,8 @@ class ClickableArea(Directive):
                 :incorrect: An array of the indices of the incorrect elements--same format as the correct elements.
                 --Content--
         """
+        addQuestionToDB(self)
+
         self.assert_has_content()
         self.options['divid'] = self.arguments[0]
         if "iscode" in self.options:

--- a/runestone/codelens/visualizer.py
+++ b/runestone/codelens/visualizer.py
@@ -22,7 +22,7 @@ from docutils.parsers.rst import Directive
 from .pg_logger import exec_script_str_local
 import json
 import six
-
+from runestone.server.componentdb import addQuestionToDB
 
 def setup(app):
     app.add_directive('codelens', Codelens)
@@ -179,6 +179,8 @@ class Codelens(Directive):
     has_content = True
 
     def run(self):
+
+        addQuestionToDB(self)
 
         self.JS_VARNAME = ""
         self.JS_VARVAL = ""

--- a/runestone/dragndrop/dragndrop.py
+++ b/runestone/dragndrop/dragndrop.py
@@ -19,6 +19,7 @@ __author__ = 'isaiahmayerchak'
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
+from runestone.server.componentdb import addQuestionToDB
 
 def setup(app):
     app.add_directive('dragndrop',DragNDrop)
@@ -135,6 +136,8 @@ class DragNDrop(Directive):
 
                 The question goes here.
         """
+        addQuestionToDB(self)
+
         self.options['divid'] = self.arguments[0]
 
         if self.content:

--- a/runestone/parsons/parsons.py
+++ b/runestone/parsons/parsons.py
@@ -20,6 +20,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
 from runestone.assess import Assessment
+from runestone.server.componentdb import addQuestionToDB
 
 
 def setup(app):
@@ -101,6 +102,8 @@ Example:
 
 
         """
+
+        addQuestionToDB(self)
 
         TEMPLATE = '''
     <pre data-component="parsons" id="%(divid)s"%(maxdist)s%(order)s%(noindent)s%(language)s>

--- a/runestone/poll/poll.py
+++ b/runestone/poll/poll.py
@@ -19,6 +19,8 @@ __author__ = 'isaiahmayerchak'
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
+from runestone.server.componentdb import addQuestionToDB
+
 
 
 def setup(app):
@@ -118,6 +120,7 @@ class Poll(Directive):
                 :option_3: Option 3
                 ...etc...(Up to 10 options in mode 2)
         """
+        addQuestionToDB(self)
 
         self.options['divid'] = self.arguments[0]
         if self.content:

--- a/runestone/server/componentdb.py
+++ b/runestone/server/componentdb.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2016  Bradley N. Miller
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import print_function
+
+from datetime import datetime
+
+__author__ = 'bmiller'
+
+import os
+from sqlalchemy import create_engine, Table, MetaData, select, delete, update
+
+
+def logSource(self):
+    sourcelog = self.state.document.settings.env.config.html_context.get('dsource', None)
+    if sourcelog:
+        with open(sourcelog, 'a') as sl:
+            sl.write("--------{}--------\n".format(self.arguments[0]))
+            sl.write(".. {}:: {}\n".format(self.name, " ".join(self.arguments)))
+            for k, v in self.options.items():
+                sl.write("   :{}: {}\n".format(k, v))
+            sl.write("   \n")
+            sl.write("   " + "   \n".join(self.content))
+            sl.write("\n")
+
+
+def addQuestionToDB(self):
+    if all(name in os.environ for name in ['DBHOST', 'DBPASS', 'DBUSER', 'DBNAME']):
+        dburl = 'postgresql://{DBUSER}:{DBPASS}@{DBHOST}/{DBNAME}'.format(**os.environ)
+    else:
+        dburl = None
+
+    if dburl:
+        sl = ""
+        sl += ".. {}:: {}\n".format(self.name, " ".join(self.arguments))
+        for k, v in self.options.items():
+            sl += "   :{}: {}\n".format(k, v)
+        sl += "   \n"
+        sl += "   " + "   \n".join(self.content)
+        sl += "\n"
+
+        basecourse = self.state.document.settings.env.config.html_context.get('basecourse', "unknown")
+        last_changed = datetime.now()
+
+        engine = create_engine(dburl)
+        meta = MetaData()
+        questions = Table('questions', meta, autoload=True, autoload_with=engine)
+
+        sel = select([questions]).where(questions.c.name == self.arguments[0])
+        res = engine.execute(sel).first()
+        if res:
+            if res['question'] != sl:
+                stmt = questions.update().where(questions.c.id == res['id']).values(question = sl, timestamp=last_changed)
+                engine.execute(stmt)
+        else:
+            ins = questions.insert().values(base_course=basecourse, name=self.arguments[0],question=sl, timestamp=last_changed)
+            engine.execute(ins)
+
+
+

--- a/runestone/shortanswer/shortanswer.py
+++ b/runestone/shortanswer/shortanswer.py
@@ -21,6 +21,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
 from runestone.assess import Assessment
+from runestone.server.componentdb import addQuestionToDB
 
 def setup(app):
     app.add_directive('shortanswer', JournalDirective)
@@ -66,6 +67,8 @@ class JournalDirective(Assessment):
 
     def run(self):
         # Raise an error if the directive does not have contents.
+
+        addQuestionToDB(self)
 
         self.assert_has_content()
 

--- a/runestone/video/video.py
+++ b/runestone/video/video.py
@@ -18,7 +18,7 @@ __author__ = 'bmiller'
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
-
+from runestone.server.componentdb import addQuestionToDB
 
 def setup(app):
     app.add_directive('video',Video)
@@ -101,6 +101,8 @@ class Video(Directive):
         :param self:
         :return:
         """
+        addQuestionToDB(self)
+
         mimeMap = {'mov':'mp4','webm':'webm', 'm4v':'m4v'}
 
         sources = [SOURCE % (directives.uri(line),mimeMap[line[line.rindex(".")+1:]]) for line in self.content]


### PR DESCRIPTION
@RunestoneInteractive/contributors 

I have tested this on the overview book and it populates the questions table quite nicely when you build.   IF the DBXXXX environment variables are defined it will attempt to update the database whenever the book is rebuilt. 

When the book is rebuilt, if a divid is already in the database, then the text of the question is compared.  If the question has changed it is updated.  If no divid is found then the question is inserted.

We are probably going to want to create a new directive like this:

```
.. component_from_db:: divid
```

This will simply get the text for the question from the database and then as Sphinx to recursively parse the inserted question.  I *think* it should work 😄    This would be the logical way to easily generate an assignment page from the instructors interface.



