### PR TITLE
Fix ActiveCode Keyboard Trap to increase Accessibility

### DIFF
--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -5,7 +5,6 @@
 var isMouseDown = false;
 document.onmousedown = function() { isMouseDown = true };
 document.onmouseup   = function() { isMouseDown = false };
-
 var edList = {};
 
 ActiveCode.prototype = new RunestoneBase();
@@ -97,9 +96,7 @@ ActiveCode.prototype.createEditor = function (index) {
     var editor = CodeMirror(codeDiv, {value: this.code, lineNumbers: true,
         mode: this.containerDiv.lang, indentUnit: 4,
         matchBrackets: true, autoMatchParens: true,
-        extraKeys: {"Tab": "indentMore", "Shift-Tab": "indentLess", "Shift-Ctrl": function(cm) {
-            this.previousSibling.focus(); // Gain focus of the previous sibling to get out of keyboard trap
-        }}
+        extraKeys: {"Tab": "indentMore", "Shift-Tab": "indentLess"}
     });
 
     // Make the editor resizable
@@ -116,9 +113,24 @@ ActiveCode.prototype.createEditor = function (index) {
             $(editor.getWrapperElement()).css('border-top', '2px solid #b43232');
             $(editor.getWrapperElement()).css('border-bottom', '2px solid #b43232');
             this.logBookEvent({'event': 'activecode', 'act': 'edit', 'div_id': this.divid});
-    }
+        }
         editor.acEditEvent = true;
-        }).bind(this));  // use bind to preserve *this* inside the on handler.
+    }).bind(this));  // use bind to preserve *this* inside the on handler.
+
+    //If user tabs into ActiveCode, change CodeMirror's extraKeys to cancel Tab/Shift-Tab indentation behavior and let user tab out the textarea
+    $(window).keyup(function (e) {
+        var code = (e.keyCode ? e.keyCode : e.which);
+        if (code == 9 && $('.CodeMirror-code:focus').length) {
+            editor.setOption("extraKeys", {
+                "Tab": function(cm) {
+                    editor.closest('.ac_actions').focus();
+                },
+                "Shift-Tab": function(cm) {
+                    editor.closest('.ac_caption').focus();
+                }
+            });
+        }
+    });
 
     this.editor = editor;
     if (this.hidecode) {

--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -118,15 +118,16 @@ ActiveCode.prototype.createEditor = function (index) {
     }).bind(this));  // use bind to preserve *this* inside the on handler.
 
     //If user tabs into ActiveCode, change CodeMirror's extraKeys to cancel Tab/Shift-Tab indentation behavior and let user tab out the textarea
-    $(window).keyup(function (e) {
+    $(window).keydown(function (e) {
         var code = (e.keyCode ? e.keyCode : e.which);
-        if (code == 9 && $('.CodeMirror-code:focus').length) {
+        if (code == 9 && $('textarea:focus').length === 0) {
             editor.setOption("extraKeys", {
                 "Tab": function(cm) {
-                    editor.closest('.ac_actions').focus();
+                    console.log($(document.activeElement).closest('.tab-content').nextSibling);
+                    $(document.activeElement).closest('.tab-content').nextSibling.focus();//working unexpectedly
                 },
                 "Shift-Tab": function(cm) {
-                    editor.closest('.ac_caption').focus();
+                    $(document.activeElement).closest('.tab-content').previousSibling.focus();
                 }
             });
         }

--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -117,14 +117,13 @@ ActiveCode.prototype.createEditor = function (index) {
         editor.acEditEvent = true;
     }).bind(this));  // use bind to preserve *this* inside the on handler.
 
-    //If user tabs into ActiveCode, change CodeMirror's extraKeys to cancel Tab/Shift-Tab indentation behavior and let user tab out the textarea
+    //Solving Keyboard Trap of ActiveCode: If user use tab for navigation outside of ActiveCode, then change tab behavior in ActiveCode to enable tab user to tab out of the textarea
     $(window).keydown(function (e) {
         var code = (e.keyCode ? e.keyCode : e.which);
         if (code == 9 && $('textarea:focus').length === 0) {
             editor.setOption("extraKeys", {
                 "Tab": function(cm) {
-                    console.log($(document.activeElement).closest('.tab-content').nextSibling);
-                    $(document.activeElement).closest('.tab-content').nextSibling.focus();//working unexpectedly
+                    $(document.activeElement).closest('.tab-content').nextSibling.focus();
                 },
                 "Shift-Tab": function(cm) {
                     $(document.activeElement).closest('.tab-content').previousSibling.focus();

--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -97,7 +97,9 @@ ActiveCode.prototype.createEditor = function (index) {
     var editor = CodeMirror(codeDiv, {value: this.code, lineNumbers: true,
         mode: this.containerDiv.lang, indentUnit: 4,
         matchBrackets: true, autoMatchParens: true,
-        extraKeys: {"Tab": "indentMore", "Shift-Tab": "indentLess"}
+        extraKeys: {"Tab": "indentMore", "Shift-Tab": "indentLess", "Shift-Ctrl": function(cm) {
+            this.previousSibling.focus(); // Gain focus of the previous sibling to get out of keyboard trap
+        }}
     });
 
     // Make the editor resizable

--- a/runestone/activecode/js/timed_activecode.js
+++ b/runestone/activecode/js/timed_activecode.js
@@ -8,6 +8,10 @@ TimedActiveCode.prototype = new ActiveCode();
 TimedActiveCode.prototype.timedInit = function (opts) {
     this.init(opts);
     //this.renderTimedIcon(this.containerDiv); - bje not needed anymore
+    if (this.language == 'javascript') {
+        TimedActiveCode.prototype.runProg = JSActiveCode.prototype.runProg;
+        TimedActiveCode.prototype.outputfun = JSActiveCode.prototype.outputfun;
+    }
     this.hideButtons();
     this.addHistoryScrubber();
     this.needsReinitialization = true;   // the run button click listener needs to be reinitialized


### PR DESCRIPTION
# Problem Addressed

For users dependent on tab navigation and screen readers (see [this page](http://webaim.org/techniques/keyboard/)), when they tab into ActiveCode's `<textarea>` the CodeMirror API changes tab function to indenting 4 spaces and there's no way to tab out of the `<textarea>` to change focus, basically prohibiting the user from further navigation.

# Solution

After discussing with @jochenrick , we came up with the following idea that if the user uses tab navigation outside of ActiveCode, then we disable ActiveCode's tab indentation behavior so that when users hit tab inside ActiveCode the focus changes to the next HTML element as usual. If the user use mouse for navigation (such as clicking into ActiveCode), the ActiveCode will work normally by indenting 4 spaces when hitting tab.

# Implementation

Within ActiveCode.js when keydown event is fired, if ActiveCode is not in focus, then we judge that the user is depending on tab navigation and change the ExtraKeys option of CodeMirror so that tab and shift-tab keys works normally.

# Testing

I've tested the solution in Chrome, Firefox, Safari and demoed this to @jochenrick in person.

# Contact

Siwei "Robert" Li

robertsiweili@gatech.edu

Georgia Institute of Technology