### PR TITLE
Enclosed data-include in quotes to fix multiple includes

### DIFF
--- a/runestone/activecode/activecode.py
+++ b/runestone/activecode/activecode.py
@@ -238,7 +238,7 @@ class ActiveCode(RunestoneDirective):
         else:
             lst = self.options['include'].split(',')
             lst = [x.strip() for x in lst]
-            self.options['include'] = 'data-include=' + " ".join(lst)
+            self.options['include'] = 'data-include="' + " ".join(lst) + '"'
 
         if 'hidecode' in self.options:
             self.options['hidecode'] = 'data-hidecode="true"'


### PR DESCRIPTION
Currently activecode is unable to include multiple snippets from other activecode  components. Value of the data-include attribute is inserted without quoting the identifiers and using a space separator.  Therefore second and later included identifiers are seen as textarea attributes instead of part of the data-include attribute.