### PR TITLE
Bug fix: nonstandard <btn> tag in timed exams

### DIFF
--- a/runestone/assess/js/timed.js
+++ b/runestone/assess/js/timed.js
@@ -144,8 +144,8 @@ Timed.prototype.renderControlButtons = function () {
         "id": "controls",
         "style": "text-align: center"
     });
-    this.startBtn = document.createElement("btn");
-    this.pauseBtn = document.createElement("btn");
+    this.startBtn = document.createElement("button");
+    this.pauseBtn = document.createElement("button");
     $(this.startBtn).attr({
         "class": "btn btn-success",
         "id": "start"


### PR DESCRIPTION
In assess/js/timed.js there are two occurrences of `<btn>` rather than the standard `<button>` that might have been caused by the confusion over bootstrap class btn. The nonstandard html <btn> cannot be focused by tab.

on line 147-148
`this.startBtn = document.createElement("btn");`
` this.pauseBtn = document.createElement("btn");`