### PR TITLE
Crucial bug: Timed Exam Answer Disclosure before Submission

### DIFF
--- a/runestone/assess/js/timedmc.js
+++ b/runestone/assess/js/timedmc.js
@@ -28,6 +28,9 @@ TimedMC.prototype.renderTimedIcon = function (component) {
 };
 
 TimedMC.prototype.hideButtons = function () {
+    //Just hiding the buttons doesn't prevent submitting the form when entering is clicked
+    //We need to completely disable the buttons
+    $(this.submitButton).attr("disabled","true");
     $(this.submitButton).hide();
     $(this.compareButton).hide();
 };


### PR DESCRIPTION
## To Reproduce
This crucial bug can be reproduced at http://interactivepython.org/runestone/static/JavaReview/Tests/test1.html 
and other pages with timed exams.

Originally discovered via Google Chrome.

Start the exam and click a radio button in the multiple choice, then press enter/return key on the keyboard, the answer of the question will show without the user submitting the exam.

## Cause of the problem
 The hideButtons() function implemented in varies timed assessments (take timedmc.js line 30 for example), only hides the submit button “Check Me” and “Compare” inherited from MultipleChoice class but doesn’t disable the functionality of submitting a form. And when radio button is selected in timedmc and enter key is pressed, the default behavior of the browser is to submit the form and thus the check me button is virtually pressed, causing the answer to disclose.

## Fix
Currently I manually disabled the submit button and the bug no longer appear.