### PR TITLE
Improve multiple-choice questions

### DIFF
--- a/runestone/assess/assess.py
+++ b/runestone/assess/assess.py
@@ -40,6 +40,10 @@ def setup(app):
     app.add_node(TimedNode, html=(visit_timed_node, depart_timed_node))
     app.add_node(MChoiceNode, html=(visit_mc_node, depart_mc_node))
 
+    app.add_node(AnswersBulletList, html=(visit_answers_bullet_node, depart_answers_bullet_node))
+    app.add_node(AnswerListItem, html=(visit_answer_list_item, depart_answer_list_item))
+    app.add_node(FeedbackBulletList, html=(visit_feedback_bullet_node, depart_feedback_bullet_node))
+    app.add_node(FeedbackListItem, html=(visit_feedback_list_item, depart_feedback_list_item))
 
 
 

--- a/runestone/assess/multiplechoice.py
+++ b/runestone/assess/multiplechoice.py
@@ -17,10 +17,7 @@ __author__ = 'bmiller'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
 from .assessbase import *
-import json
-import random
 from runestone.server.componentdb import addQuestionToDB, addHTMLToDB
 
 
@@ -45,7 +42,8 @@ def visit_mc_node(self,node):
         node.mc_options['random'] = 'data-random'
     else:
         node.mc_options['random'] = ''
-    if 'multiple_answers' in node.mc_options:
+    # Use multiple_answers behavior if explicitly required or if multiple correct answers were provided.
+    if ('multiple_answers' in node.mc_options) or (',' in node.mc_options['correct']):
         node.mc_options['multipleAnswers'] = 'true'
     else:
         node.mc_options['multipleAnswers'] = 'false'
@@ -93,22 +91,46 @@ def depart_mc_node(self,node):
 # author - Anusha
 class MChoice(Assessment):
     """
-.. mchoice:: uniqueid
-   :multiple_answers: boolean  [optional]
-   :random: boolean [optional]
-   :answer_a: possible answer  -- what follows _ is label
-   :answer_b: possible answer
-   ...
-   :answer_e: possible answer
-   :correct: letter of correct answer or list of correct answer letters (in case of multiple answers)
-   :feedback_a: displayed if a is picked
-   :feedback_b: displayed if b is picked
-   :feedback_c: displayed if c is picked
-   :feedback_d: displayed if d is picked
-   :feedback_e: displayed if e is picked
+    The syntax for a multiple-choice question is:
 
-   Question text   ...
+    .. mchoice:: uniqueid
+        :correct: letter of correct answer or list of correct answer letters (in case of multiple answers)
+        :multiple_answers: boolean  [optional]. Implied if ``:correct:`` contains a list.
+        :random: boolean [optional]
 
+        The following arguments supply answers and feedback. See below for an alternative method of specification.
+
+        :answer_a: possible answer  -- what follows _ is label
+        :answer_b: possible answer
+        :answer_c: possible answer
+        :answer_d: possible answer
+        :answer_e: possible answer
+        :feedback_a: displayed if a is picked
+        :feedback_b: displayed if b is picked
+        :feedback_c: displayed if c is picked
+        :feedback_d: displayed if d is picked
+        :feedback_e: displayed if e is picked
+
+        Question text ...
+
+        Alternative method of specifying answers and feedback: Place an `unordered list <http://www.sphinx-doc.org/en/stable/rest.html#lists-and-quote-like-blocks>`_
+        at the end of the question text, in the following format:
+
+        -   Text for answer A.
+
+            Your text may be multiple paragraphs, including `images <http://www.sphinx-doc.org/en/stable/rest.html#images>`_
+            and any other `inline <http://www.sphinx-doc.org/en/stable/rest.html#inline-markup>`_ or block markup. For example: :math:`\sqrt(2)/2`.
+
+            -   Feedback for answer A.
+
+                This may also span multiple paragraphs and include any markup.
+                However, there can be only one item in this unordered list.
+
+        - Text for answer B.
+
+            -   Feedback for answer B.
+
+        ... and so on.
     """
     required_arguments = 1
     optional_arguments = 1
@@ -178,7 +200,128 @@ class MChoice(Assessment):
         mcNode.template_end = TEMPLATE_END
 
         self.state.nested_parse(self.content, self.content_offset, mcNode)
+
+        # Expected _`structure`, with assigned variable names and transformations made:
+        #
+        # .. code-block::
+        #   :number-lines:
+        #
+        #
+        #   mcNode = MChoiceNode()
+        #       Item 1 of problem text
+        #       ...
+        #       Item n of problem text
+        #       answers_bullet_list = bullet_list() -> AnswersBulletList() <-- last item of mcNode may be a bulleted list of answers and feedback.
+        #           answer_list_item = list_item() -> AnswerListItem()
+        #               Item 1 of text for answer A
+        #               ...
+        #               Item n of text for answer A
+        #               feedback_bullet_list = bullet_list() -> FeedbackBulletList() <-- last item must be a bulleted list containing feedback.
+        #                   feedback_list_item = list_item() -> FeedbackListItem()   <-- A single item in the list, which contains the feedback.
+        #           answer_list_item = list_item() -> AnswerListItem()
+        #               Item 1 of text for answer B
+        #               ...and so on...
+        #
+        # See if the last item is a list. If so, and questions/answers weren't specified as options, assume it contains questions and answers.
+        answers_bullet_list = mcNode[-1]
+        if isinstance(answers_bullet_list, nodes.bullet_list) and ('answer_a' not in self.options):
+            # Walk it, processing each answer and its associated feedback.
+            for answer_list_item in answers_bullet_list:
+                assert isinstance(answer_list_item, nodes.list_item)
+
+                # Look for the feedback for this answer -- the last child of this answer list item.
+                feedback_bullet_list = answer_list_item[-1]
+                assert isinstance(feedback_bullet_list, nodes.bullet_list)
+                # It should have just one item (the feedback itself).
+                assert len(feedback_bullet_list) == 1
+
+                # Change the feedback list item (which is currently a generic list_item) to our special node class (a FeedbackListItem).
+                feedback_list_item = feedback_bullet_list[0]
+                assert isinstance(feedback_list_item, nodes.list_item)
+                feedback_list_item.replace_self(FeedbackListItem(feedback_list_item.rawsource, *feedback_list_item.children, **feedback_list_item.attributes))
+
+                # Change the feedback bulleted list (currently a bullet_list) to our class (a FeedbackBulletList).
+                feedback_bullet_list.replace_self(FeedbackBulletList(feedback_bullet_list.rawsource, *feedback_bullet_list.children, **feedback_bullet_list.attributes))
+
+                # Change the answer list item (currently a list_item) to an AnswerListItem.
+                answer_list_item.replace_self(AnswerListItem(answer_list_item.rawsource, *answer_list_item.children, **answer_list_item.attributes))
+
+            # Change the answer bulleted list (currently a bullet_list) to an AnswersBulletList.
+            answers_bullet_list.replace_self(AnswersBulletList(answers_bullet_list.rawsource, *answers_bullet_list.children, **answers_bullet_list.attributes))
+
         return [mcNode]
+
+
+# Define a bullet_list which contains answers (see the structure_).
+class AnswersBulletList(nodes.bullet_list):
+    pass
+
+# Define a list_item which contains answers (see the structure_).
+class AnswerListItem(nodes.list_item):
+    pass
+
+# Define a bullet_list which contains feedback (see the structure_).
+class FeedbackBulletList(nodes.bullet_list):
+    pass
+
+# Define a list_item which contains answers (see the structure_).
+class FeedbackListItem(nodes.list_item):
+    pass
+
+# The ``<ul>`` tag will be generated already -- don't output it.
+def visit_answers_bullet_node(self, node):
+    # Prevent the list items, which are wrapped in ``<paragraph>`` tags, from emitting the ``<p>``. See similar code in ``docutils.writers._html_base.HTMLTranslator.visit_bullet_list`` and its use in ``docutils.writer.html4css1.HTMLTranslator.visit_paragraph``.
+    self.context.append((self.compact_simple, self.compact_p))
+    self.compact_p = None
+    self.compact_simple = True
+
+# The ``</ul>`` tag will be generated already -- don't output it.
+def depart_answers_bullet_node(self, node):
+    # Restore the state modified in ``visit_answers_bullet_node``.
+    self.compact_simple, self.compact_p = self.context.pop()
+
+# Write out the special attributes needed by the ``<li>`` tag.
+def visit_answer_list_item(self, node):
+    # See the structure_.
+    mcNode = node.parent.parent
+
+    # _`label`: Turn the index of this item in the answer_bullet_list (see structure_) into a letter.
+    label = chr(node.parent.index(node) + ord('a'))
+    # Update dict for formatting the HTML.
+    mcNode.mc_options['alabel'] = label
+    mcNode.mc_options['letter'] = label.upper()
+    if label in mcNode.mc_options['correct']:
+        mcNode.mc_options['is_correct'] = 'data-correct'
+    else:
+        mcNode.mc_options['is_correct'] = ''
+
+    # Format the HTML.
+    self.body.append('<li data-component="answer" %(is_correct)s id="%(divid)s_opt_%(alabel)s">(%(letter)s) ' % mcNode.mc_options)
+
+# Although the feedback for an answer is given as a sublist, the HTML is just a list. So, let the feedback list item close this list.
+def depart_answer_list_item(self, node):
+    pass
+
+# Nothing to output, since feedback isn't nested under an answer in the HTML.
+def visit_feedback_bullet_node(self, node):
+    pass
+
+# Nothing to output, since feedback isn't nested under an answer in the HTML.
+def depart_feedback_bullet_node(self, node):
+    pass
+
+def visit_feedback_list_item(self, node):
+    # See label_ and structure_.
+    answer_list_item = node.parent.parent
+    mcNode = answer_list_item.parent.parent
+    label = chr(answer_list_item.parent.index(answer_list_item) + ord('a'))
+    mcNode.mc_options['alabel'] = label
+    self.body.append('</li><li data-component="feedback" id="%(divid)s_opt_%(alabel)s">\n' % mcNode.mc_options)
+
+def depart_feedback_list_item(self, node):
+    self.body.append('</li>')
+
+
 
 #backwards compatibility
 class MChoiceMF(MChoice):


### PR DESCRIPTION
This PR contains three changes. The first two are fairly minor:

1. A bit of cleanup -- removing unused imports.
2. A fix to assume that multiple-choice questions whose `:correct:` field contains a list is a multiple-answer question.

The third is the primary change:

3. Allow block or inline markup as part of the question and feedback text by optionally specifying these as a bulleted list.

I use [CodeChat](https://pythonhosted.org/CodeChat/README.html), which allows me to render reStructuredText in comments nicely, hence some of the formatting in comments.

Feel free to request changes/edits/whatever, given that this is my first PR to this project. I look forward to meeting everyone in person next week!