### PR TITLE
Fix Selenium tests; improve reST error reporting

### DIFF
--- a/runestone/activecode/activecode.py
+++ b/runestone/activecode/activecode.py
@@ -353,6 +353,7 @@ class ActiveCode(RunestoneDirective):
 
 
         acnode = ActivcodeNode(self.options)
+        acnode.source, acnode.line = self.state_machine.get_source_and_line(self.lineno)
         self.add_name(acnode)    # make this divid available as a target for :ref:
 
         if explain_text:

--- a/runestone/activecode/activecode.py
+++ b/runestone/activecode/activecode.py
@@ -19,12 +19,10 @@ __author__ = 'bmiller'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
 from .textfield import *
-from sqlalchemy import create_engine, Table, MetaData, select, delete
-from runestone.server import get_dburl
+from sqlalchemy import Table
 from runestone.server.componentdb import addQuestionToDB, addHTMLToDB, engine, meta
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 try:
     from html import escape  # py3
@@ -69,15 +67,15 @@ TEMPLATE_END = """
 </div>
 """
 
-class ActivcodeNode(nodes.General, nodes.Element):
-    def __init__(self, content):
+class ActivcodeNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self, content, **kwargs):
         """
 
         Arguments:
         - `self`:
         - `content`:
         """
-        super(ActivcodeNode, self).__init__(name=content['name'])
+        super(ActivcodeNode, self).__init__(name=content['name'], **kwargs)
         self.ac_components = content
 
 
@@ -352,7 +350,7 @@ class ActiveCode(RunestoneDirective):
             print("This should only affect the grading interface. Everything else should be fine.")
 
 
-        acnode = ActivcodeNode(self.options)
+        acnode = ActivcodeNode(self.options, rawsource=self.block_text)
         acnode.source, acnode.line = self.state_machine.get_source_and_line(self.lineno)
         self.add_name(acnode)    # make this divid available as a target for :ref:
 

--- a/runestone/activecode/test/test_activecode.py
+++ b/runestone/activecode/test/test_activecode.py
@@ -1,5 +1,8 @@
-from runestone.unittest_base import module_fixture_maker, RunestoneTestCase
 from selenium.webdriver import ActionChains
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+from runestone.unittest_base import module_fixture_maker, RunestoneTestCase
 
 setUpModule, tearDownModule = module_fixture_maker(__file__)
 
@@ -39,6 +42,7 @@ class ActiveCodeTests(RunestoneTestCase):
         ta = t1.find_element_by_class_name("cm-s-default")
         self.assertIsNotNone(ta)
         self.driver.execute_script("""edList['test1'].editor.setValue("print('GoodBye')")""")
+        WebDriverWait(self.driver, 10).until(EC.element_to_be_clickable((By.CLASS_NAME, "run-button")))
         rb.click()
         output = t1.find_element_by_class_name("ac_output")
         self.assertEqual(output.text.strip(),"GoodBye")

--- a/runestone/animation/animation.py
+++ b/runestone/animation/animation.py
@@ -17,7 +17,7 @@ __author__ = 'bmiller'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
+from runestone.common.runestonedirective import RunestoneDirective
 
 
 def setup(app):
@@ -52,7 +52,7 @@ SRC = '''
 
 SCRIPTTAG = '''<script type="text/javascript" src="../_static/%s"></script>\n'''
 
-class Animation(Directive):
+class Animation(RunestoneDirective):
     required_arguments = 1
     optional_arguments = 1
     final_argument_whitespace = True
@@ -80,7 +80,7 @@ class Animation(Directive):
 
 
         res = res + SRC % self.options
-        rawnode = nodes.raw('',res , format='html')
+        rawnode = nodes.raw(self.block_text, res, format='html')
         rawnode.source, rawnode.line = self.state_machine.get_source_and_line(self.lineno)
         return [rawnode]
 

--- a/runestone/animation/animation.py
+++ b/runestone/animation/animation.py
@@ -80,7 +80,9 @@ class Animation(Directive):
 
 
         res = res + SRC % self.options
-        return [nodes.raw('',res , format='html')]
+        rawnode = nodes.raw('',res , format='html')
+        rawnode.source, rawnode.line = self.state_machine.get_source_and_line(self.lineno)
+        return [rawnode]
 
 
 source = '''

--- a/runestone/assess/assess.py
+++ b/runestone/assess/assess.py
@@ -79,7 +79,9 @@ class AddButton(Directive):
         res = TEMPLATE_START % self.options
 
         res += TEMPLATE_END % self.options
-        return [nodes.raw('', res, format='html')]
+        rawnode = nodes.raw('', res, format='html')
+        rawnode.source, rawnode.line = self.state_machine.get_source_and_line(self.lineno)
+        return [rawnode]
 
 
 class QuestionNumber(Directive):

--- a/runestone/assess/assess.py
+++ b/runestone/assess/assess.py
@@ -17,7 +17,7 @@ __author__ = 'bmiller'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
+from runestone.common.runestonedirective import RunestoneDirective
 from .assessbase import Assessment
 from .multiplechoice import *
 from .timedassessment import *
@@ -47,7 +47,7 @@ def setup(app):
 
 
 
-class AddButton(Directive):
+class AddButton(RunestoneDirective):
     required_arguments = 1
     optional_arguments = 1
     final_argument_whitespace = True
@@ -79,12 +79,12 @@ class AddButton(Directive):
         res = TEMPLATE_START % self.options
 
         res += TEMPLATE_END % self.options
-        rawnode = nodes.raw('', res, format='html')
+        rawnode = nodes.raw(self.block_text, res, format='html')
         rawnode.source, rawnode.line = self.state_machine.get_source_and_line(self.lineno)
         return [rawnode]
 
 
-class QuestionNumber(Directive):
+class QuestionNumber(RunestoneDirective):
     """Set Parameters for Question Numbering
 .. qnum::
    'prefix': character prefix before the number

--- a/runestone/assess/assessbase.py
+++ b/runestone/assess/assessbase.py
@@ -15,10 +15,7 @@
 #
 __author__ = 'bmiller'
 
-from docutils import nodes
-from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 _base_js_escapes = (
     ('\\', r'\u005C'),
@@ -76,7 +73,7 @@ class Assessment(RunestoneDirective):
     def run(self):
 
         self.options['qnumber'] = self.getNumber()
-        
+
         self.options['divid'] = self.arguments[0]
 
         if self.content[0][:2] == '..':  # first line is a directive

--- a/runestone/assess/multiplechoice.py
+++ b/runestone/assess/multiplechoice.py
@@ -195,6 +195,7 @@ class MChoice(Assessment):
 
 
         mcNode = MChoiceNode(self.options)
+        mcNode.source, mcNode.line = self.state_machine.get_source_and_line(self.lineno)
         mcNode.template_start = TEMPLATE_START
         mcNode.template_option = OPTION
         mcNode.template_end = TEMPLATE_END

--- a/runestone/assess/multiplechoice.py
+++ b/runestone/assess/multiplechoice.py
@@ -21,15 +21,15 @@ from .assessbase import *
 from runestone.server.componentdb import addQuestionToDB, addHTMLToDB
 
 
-class MChoiceNode(nodes.General, nodes.Element):
-    def __init__(self,content):
+class MChoiceNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self, content, **kwargs):
         """
 
         Arguments:
         - `self`:
         - `content`:
         """
-        super(MChoiceNode,self).__init__()
+        super(MChoiceNode, self).__init__(**kwargs)
         self.mc_options = content
 
 def visit_mc_node(self,node):
@@ -194,7 +194,7 @@ class MChoice(Assessment):
 
 
 
-        mcNode = MChoiceNode(self.options)
+        mcNode = MChoiceNode(self.options, rawsource=self.block_text)
         mcNode.source, mcNode.line = self.state_machine.get_source_and_line(self.lineno)
         mcNode.template_start = TEMPLATE_START
         mcNode.template_option = OPTION
@@ -278,19 +278,19 @@ class MChoice(Assessment):
 
 
 # Define a bullet_list which contains answers (see the structure_).
-class AnswersBulletList(nodes.bullet_list):
+class AnswersBulletList(nodes.bullet_list, RunestoneNode):
     pass
 
 # Define a list_item which contains answers (see the structure_).
-class AnswerListItem(nodes.list_item):
+class AnswerListItem(nodes.list_item, RunestoneNode):
     pass
 
 # Define a bullet_list which contains feedback (see the structure_).
-class FeedbackBulletList(nodes.bullet_list):
+class FeedbackBulletList(nodes.bullet_list, RunestoneNode):
     pass
 
 # Define a list_item which contains answers (see the structure_).
-class FeedbackListItem(nodes.list_item):
+class FeedbackListItem(nodes.list_item, RunestoneNode):
     pass
 
 # The ``<ul>`` tag will be generated already -- don't output it.

--- a/runestone/assess/timedassessment.py
+++ b/runestone/assess/timedassessment.py
@@ -42,12 +42,12 @@ def visit_timed_node(self, node):
         node.timed_options['nofeedback'] = 'data-no-feedback'
     else:
         node.timed_options['nofeedback'] = ''
-        
+
     if 'notimer' in node.timed_options:
         node.timed_options['notimer'] = 'data-no-timer'
     else:
         node.timed_options['notimer'] = ''
-        
+
     if 'fullwidth' in node.timed_options:
         node.timed_options['fullwidth'] = 'data-fullwidth'
     else:
@@ -107,6 +107,7 @@ class TimedDirective(Directive):
         self.options['divid'] = self.arguments[0]
 
         timed_node = TimedNode(self.options)
+        timed_node.source, timed_node.line = self.state_machine.get_source_and_line(self.lineno)
 
         self.state.nested_parse(self.content, self.content_offset, timed_node)
 

--- a/runestone/assess/timedassessment.py
+++ b/runestone/assess/timedassessment.py
@@ -14,12 +14,12 @@ __author__ = 'isaiahmayerchak'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 #add directives/javascript/css
 
 
-class TimedNode(nodes.General, nodes.Element):
+class TimedNode(nodes.General, nodes.Element, RunestoneNode):
     def __init__(self,content):
         super(TimedNode,self).__init__()
         self.timed_options = content
@@ -69,7 +69,7 @@ TEMPLATE_START = '''
 
 TEMPLATE_END = '''</ul>
     '''
-class TimedDirective(Directive):
+class TimedDirective(RunestoneDirective):
     """
 .. timed:: identifier
     :timelimit: Number of minutes student has to take the timed assessment--if not provided, no time limit
@@ -106,7 +106,7 @@ class TimedDirective(Directive):
 
         self.options['divid'] = self.arguments[0]
 
-        timed_node = TimedNode(self.options)
+        timed_node = TimedNode(self.options, rawsource=self.block_text)
         timed_node.source, timed_node.line = self.state_machine.get_source_and_line(self.lineno)
 
         self.state.nested_parse(self.content, self.content_offset, timed_node)

--- a/runestone/assignment/__init__.py
+++ b/runestone/assignment/__init__.py
@@ -19,9 +19,8 @@ __author__ = 'Paul Resnick'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
 from runestone.server.componentdb import addAssignmentToDB, addAssignmentQuestionToDB, getCourseID, getOrCreateAssignmentType, getQuestionID, get_HTML_from_DB
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 from datetime import datetime
 
 def setup(app):
@@ -31,15 +30,15 @@ def setup(app):
     app.connect('doctree-resolved',process_nodes)
     app.connect('env-purge-doc', purge)
 
-class AssignmentNode(nodes.General, nodes.Element):
-    def __init__(self, content):
+class AssignmentNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self, content, **kwargs):
         """
 
         Arguments:
         - `self`:
         - `content`:
         """
-        super(AssignmentNode, self).__init__(name=content['name'])
+        super(AssignmentNode, self).__init__(name=content['name'], **kwargs)
         self.a_components = content
 
 
@@ -157,7 +156,7 @@ class Assignment(RunestoneDirective):
         self.options['question_ids'] = question_names
 
         if 'generate_html' in self.options:
-            assignment_node = AssignmentNode(self.options)
+            assignment_node = AssignmentNode(self.options, rawsource=self.block_text)
             assignment_node.source, assignment_node.line = self.state_machine.get_source_and_line(self.lineno)
             return [assignment_node]
         else:

--- a/runestone/assignment/__init__.py
+++ b/runestone/assignment/__init__.py
@@ -157,6 +157,8 @@ class Assignment(RunestoneDirective):
         self.options['question_ids'] = question_names
 
         if 'generate_html' in self.options:
-            return [AssignmentNode(self.options)]
+            assignment_node = AssignmentNode(self.options)
+            assignment_node.source, assignment_node.line = self.state_machine.get_source_and_line(self.lineno)
+            return [assignment_node]
         else:
             return []

--- a/runestone/blockly/blockly.py
+++ b/runestone/blockly/blockly.py
@@ -16,11 +16,10 @@
 
 __author__ = 'bmiller'
 
-from docutils import nodes
-from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
-import json
 import os
+from docutils import nodes
+from runestone.common import RunestoneDirective, RunestoneNode
+
 
 # try:
 #     import conf
@@ -45,15 +44,15 @@ def setup(app):
 
 
 #'
-class BlocklyNode(nodes.General, nodes.Element):
-    def __init__(self,content):
+class BlocklyNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self,content, **kwargs):
         """
 
         Arguments:
         - `self`:
         - `content`:
         """
-        super(BlocklyNode,self).__init__()
+        super(BlocklyNode,self).__init__(**kwargs)
         self.ac_components = content
 
 
@@ -199,7 +198,7 @@ def purge_activecodes(app,env,docname):
     pass
 
 
-class Blockly(Directive):
+class Blockly(RunestoneDirective):
     required_arguments = 1
     optional_arguments = 0
     has_content = True
@@ -222,7 +221,7 @@ class Blockly(Directive):
         if self.content:
             self.options['controls'] = self.content[:plstart]
 
-        blockly_node = BlocklyNode(self.options)
+        blockly_node = BlocklyNode(self.options, rawsource=self.block_text)
         blockly_node.source, blockly_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [blockly_node]
 

--- a/runestone/blockly/blockly.py
+++ b/runestone/blockly/blockly.py
@@ -134,14 +134,14 @@ END = '''
       }
     }
 
-    Blockly.JavaScript['text_print'] = function(block) { 
-      // Print statement override. 
-      var argument0 = Blockly.JavaScript.valueToCode(block, 'TEXT', 
-          Blockly.JavaScript.ORDER_NONE) || '\\'\\''; 
-      return 'my_custom_print(' + argument0 + ', "%(divid)s" );\\n'; 
-    }; 
+    Blockly.JavaScript['text_print'] = function(block) {
+      // Print statement override.
+      var argument0 = Blockly.JavaScript.valueToCode(block, 'TEXT',
+          Blockly.JavaScript.ORDER_NONE) || '\\'\\'';
+      return 'my_custom_print(' + argument0 + ', "%(divid)s" );\\n';
+    };
 
-    function my_custom_print(text,divid) { 
+    function my_custom_print(text,divid) {
       var p = document.getElementById(divid+"_pre");
       p.innerHTML += text + "\\n"
       }
@@ -151,7 +151,7 @@ END = '''
     Blockly.Xml.domToWorkspace(Blockly.mainWorkspace, xmlDom);
 
   </script>
-  
+
   <pre class="active_out" id="%(divid)s_pre"></pre>
   </body>
   </html>
@@ -213,7 +213,7 @@ class Blockly(Directive):
 
         pathDepth = rel_filename.count("/")
         self.options['blocklyHomePrefix'] = "../"*pathDepth
-        
+
         plstart = len(self.content)
         if 'preload::' in self.content:
             plstart = self.content.index('preload::')
@@ -221,21 +221,23 @@ class Blockly(Directive):
 
         if self.content:
             self.options['controls'] = self.content[:plstart]
-        
-        return [BlocklyNode(self.options)]
+
+        blockly_node = BlocklyNode(self.options)
+        blockly_node.source, blockly_node.line = self.state_machine.get_source_and_line(self.lineno)
+        return [blockly_node]
 
 
 
 
 '''
-    Blockly.JavaScript['text_print'] = function(block) { 
-      // Print statement override. 
-      var argument0 = Blockly.JavaScript.valueToCode(block, 'TEXT', 
-          Blockly.JavaScript.ORDER_NONE) || '\'\''; 
-      return 'my_custom_print(' + argument0 + ');\n'; 
-    }; 
+    Blockly.JavaScript['text_print'] = function(block) {
+      // Print statement override.
+      var argument0 = Blockly.JavaScript.valueToCode(block, 'TEXT',
+          Blockly.JavaScript.ORDER_NONE) || '\'\'';
+      return 'my_custom_print(' + argument0 + ');\n';
+    };
 
-    function my_custom_print(text) { 
+    function my_custom_print(text) {
       var p = document.getElementById("blockly1_pre");
       p.innerHTML += text
       }
@@ -244,16 +246,16 @@ class Blockly(Directive):
 
 
 # to preload blockly with a finished or partial program, do the following
-# 
+#
 # https://blockly-demo.appspot.com/static/apps/code/index.html?lang=en
-# 
+#
 # Now save the xml string.  And append something like the following to the script after blockly
 # is created:
-# 
+#
 #       var xmlText = '<xml>  <block type="variables_set" id="1" inline="true" x="25" y="9">    <field name="VAR">X</field>    <value name="VALUE">      <block type="math_number" id="2">        <field name="NUM">10</field>      </block>    </value>  </block></xml>'
 #       xmlDom = Blockly.Xml.textToDom(xmlText);
 #       Blockly.Xml.domToWorkspace(Blockly.mainWorkspace, xmlDom);
- 
+
 
 
 

--- a/runestone/clickableArea/clickable.py
+++ b/runestone/clickableArea/clickable.py
@@ -141,6 +141,7 @@ class ClickableArea(RunestoneDirective):
         else:
             self.options['clickcode'] = ''
         clickNode = ClickableAreaNode(self.options)
+        clickNode.source, clickNode.line = self.state_machine.get_source_and_line(self.lineno)
         clickNode.template_start = TEMPLATE
 
         if "table" in self.options:

--- a/runestone/clickableArea/clickable.py
+++ b/runestone/clickableArea/clickable.py
@@ -18,9 +18,8 @@ __author__ = 'isaiahmayerchak'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
 from runestone.server.componentdb import addQuestionToDB, addHTMLToDB
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 def setup(app):
     app.add_directive('clickablearea',ClickableArea)
@@ -39,14 +38,14 @@ TEMPLATE_END = """
 </div>
 """
 
-class ClickableAreaNode(nodes.General, nodes.Element):
-    def __init__(self,content):
+class ClickableAreaNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self,content, **kwargs):
         """
         Arguments:
         - `self`:
         - `content`:
         """
-        super(ClickableAreaNode,self).__init__()
+        super(ClickableAreaNode,self).__init__(**kwargs)
         self.ca_options = content
 
 # self for these functions is an instance of the writer class.  For example
@@ -140,7 +139,7 @@ class ClickableArea(RunestoneDirective):
             self.options['clickcode'] = source
         else:
             self.options['clickcode'] = ''
-        clickNode = ClickableAreaNode(self.options)
+        clickNode = ClickableAreaNode(self.options, rawsource=self.block_text)
         clickNode.source, clickNode.line = self.state_machine.get_source_and_line(self.lineno)
         clickNode.template_start = TEMPLATE
 

--- a/runestone/codelens/visualizer.py
+++ b/runestone/codelens/visualizer.py
@@ -238,7 +238,9 @@ class Codelens(RunestoneDirective):
         else:
             res += '</div>'
         addHTMLToDB(self.options['divid'], self.options['basecourse'], res % self.options)
-        return [nodes.raw('', res % self.options, format='html')]
+        raw_node = nodes.raw('', res % self.options, format='html')
+        raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
+        return [raw_node]
 
     def inject_questions(self, curTrace):
         if 'breakline' not in self.options:

--- a/runestone/codelens/visualizer.py
+++ b/runestone/codelens/visualizer.py
@@ -18,7 +18,6 @@ __author__ = 'bmiller'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
 from .pg_logger import exec_script_str_local
 import json
 import six
@@ -238,7 +237,7 @@ class Codelens(RunestoneDirective):
         else:
             res += '</div>'
         addHTMLToDB(self.options['divid'], self.options['basecourse'], res % self.options)
-        raw_node = nodes.raw('', res % self.options, format='html')
+        raw_node = nodes.raw(self.block_text, res % self.options, format='html')
         raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [raw_node]
 

--- a/runestone/common/__init__.py
+++ b/runestone/common/__init__.py
@@ -1,1 +1,1 @@
-from .runestonedirective import RunestoneDirective
+from .runestonedirective import RunestoneDirective, RunestoneNode

--- a/runestone/common/runestonedirective.py
+++ b/runestone/common/runestonedirective.py
@@ -21,6 +21,11 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
 import os
 
+# Provide a class which all Runestone nodes will inherit from.
+class RunestoneNode(nodes.Node):
+    pass
+
+
 # Notes
 # env = self.state.document.settings.env
 # env.config.html_context['course_id']

--- a/runestone/datafile/__init__.py
+++ b/runestone/datafile/__init__.py
@@ -19,10 +19,9 @@ __author__ = 'isaiahmayerchak'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
-from sqlalchemy import create_engine, Table, MetaData, select, delete
+from sqlalchemy import Table
 from runestone.server.componentdb import engine, meta
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 def setup(app):
     app.add_directive('datafile',DataFile)
@@ -43,14 +42,14 @@ TEMPLATE = """
 %(filecontent)s</pre>
 """
 
-class DataFileNode(nodes.General, nodes.Element):
-    def __init__(self,content):
+class DataFileNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self,content, **kwargs):
         """
         Arguments:
         - `self`:
         - `content`:
         """
-        super(DataFileNode,self).__init__()
+        super(DataFileNode,self).__init__(**kwargs)
         self.df_content = content
 
 # self for these functions is an instance of the writer class.  For example
@@ -166,6 +165,6 @@ class DataFile(RunestoneDirective):
             print("This should only affect the grading interface. Everything else should be fine.")
 
 
-        data_file_node = DataFileNode(self.options)
+        data_file_node = DataFileNode(self.options, rawsource=self.block_text)
         data_file_node.source, data_file_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [data_file_node]

--- a/runestone/datafile/__init__.py
+++ b/runestone/datafile/__init__.py
@@ -166,4 +166,6 @@ class DataFile(RunestoneDirective):
             print("This should only affect the grading interface. Everything else should be fine.")
 
 
-        return [DataFileNode(self.options)]
+        data_file_node = DataFileNode(self.options)
+        data_file_node.source, data_file_node.line = self.state_machine.get_source_and_line(self.lineno)
+        return [data_file_node]

--- a/runestone/disqus/disqus.py
+++ b/runestone/disqus/disqus.py
@@ -17,7 +17,7 @@ __author__ = 'isaacdontjelindell'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 
 DISQUS_BOX = """\
@@ -70,9 +70,9 @@ def setup(app):
     app.connect('doctree-resolved' ,process_disqus_nodes)
     app.connect('env-purge-doc', purge_disqus_nodes)
 
-class DisqusNode(nodes.General, nodes.Element):
-    def __init__(self,content):
-        super(DisqusNode,self).__init__()
+class DisqusNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self,content, **kwargs):
+        super(DisqusNode,self).__init__(**kwargs)
         self.disqus_components = content
 
 
@@ -94,7 +94,7 @@ def purge_disqus_nodes(app, env, docname):
     pass
 
 
-class DisqusDirective(Directive):
+class DisqusDirective(RunestoneDirective):
     """
 .. disqus::
    :shortname: Your registered disqus id
@@ -116,6 +116,6 @@ class DisqusDirective(Directive):
         :return:
         """
 
-        disqus_node = DisqusNode(self.options)
+        disqus_node = DisqusNode(self.options, rawsource=self.block_text)
         disqus_node.source, disqus_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [disqus_node]

--- a/runestone/disqus/disqus.py
+++ b/runestone/disqus/disqus.py
@@ -22,7 +22,7 @@ from docutils.parsers.rst import Directive
 
 DISQUS_BOX = """\
 <script type="text/javascript">
-    function %(identifier)s_disqus(source) { 
+    function %(identifier)s_disqus(source) {
         if (window.DISQUS) {
 
             $('#disqus_thread').insertAfter(source); //put the DIV for the Disqus box after the link
@@ -41,7 +41,7 @@ DISQUS_BOX = """\
             $('<div id="disqus_thread"></div>').insertAfter(source);
 
             // set Disqus required vars
-            disqus_shortname = '%(shortname)s';    
+            disqus_shortname = '%(shortname)s';
             disqus_identifier = '%(identifier)s_' + eBookConfig.course;
             disqus_url = 'http://%(identifier)s_'+eBookConfig.course+'.interactivepython.com/#!';
 
@@ -65,7 +65,7 @@ DISQUS_LINK = """
 
 def setup(app):
     app.add_directive('disqus', DisqusDirective)
-    
+
     app.add_node(DisqusNode, html=(visit_disqus_node, depart_disqus_node))
     app.connect('doctree-resolved' ,process_disqus_nodes)
     app.connect('env-purge-doc', purge_disqus_nodes)
@@ -77,7 +77,7 @@ class DisqusNode(nodes.General, nodes.Element):
 
 
 def visit_disqus_node(self, node):
-    res = DISQUS_BOX   
+    res = DISQUS_BOX
     res += DISQUS_LINK
 
     res = res % node.disqus_components
@@ -116,5 +116,6 @@ class DisqusDirective(Directive):
         :return:
         """
 
-        return [DisqusNode(self.options)]
-
+        disqus_node = DisqusNode(self.options)
+        disqus_node.source, disqus_node.line = self.state_machine.get_source_and_line(self.lineno)
+        return [disqus_node]

--- a/runestone/dragndrop/dragndrop.py
+++ b/runestone/dragndrop/dragndrop.py
@@ -20,7 +20,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
 from runestone.server.componentdb import addQuestionToDB, addHTMLToDB
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 def setup(app):
     app.add_directive('dragndrop',DragNDrop)
@@ -45,14 +45,14 @@ TEMPLATE_OPTION = """
 TEMPLATE_END = """</ul></div>"""
 
 
-class DragNDropNode(nodes.General, nodes.Element):
-    def __init__(self,content):
+class DragNDropNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self,content, **kwargs):
         """
         Arguments:
         - `self`:
         - `content`:
         """
-        super(DragNDropNode,self).__init__()
+        super(DragNDropNode,self).__init__(**kwargs)
         self.dnd_options = content
 
 # self for these functions is an instance of the writer class.  For example
@@ -161,7 +161,7 @@ class DragNDrop(RunestoneDirective):
         self.options['question'] = source
 
 
-        dndNode = DragNDropNode(self.options)
+        dndNode = DragNDropNode(self.options, rawsource=self.block_text)
         dndNode.source, dndNode.line = self.state_machine.get_source_and_line(self.lineno)
         dndNode.template_start = TEMPLATE_START
         dndNode.template_option = TEMPLATE_OPTION

--- a/runestone/dragndrop/dragndrop.py
+++ b/runestone/dragndrop/dragndrop.py
@@ -162,6 +162,7 @@ class DragNDrop(RunestoneDirective):
 
 
         dndNode = DragNDropNode(self.options)
+        dndNode.source, dndNode.line = self.state_machine.get_source_and_line(self.lineno)
         dndNode.template_start = TEMPLATE_START
         dndNode.template_option = TEMPLATE_OPTION
         dndNode.template_end = TEMPLATE_END

--- a/runestone/external/external.py
+++ b/runestone/external/external.py
@@ -104,6 +104,7 @@ class ExternalDirective(RunestoneDirective):
         self.options['name'] = self.arguments[0].strip()
 
         external_node = ExternalNode(self.options)
+        external_node.source, external_node.line = self.state_machine.get_source_and_line(self.lineno)
         self.add_name(external_node)
 
         self.state.nested_parse(self.content, self.content_offset, external_node)

--- a/runestone/external/external.py
+++ b/runestone/external/external.py
@@ -16,11 +16,8 @@
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from runestone.common.runestonedirective import RunestoneDirective
-from docutils.parsers.rst import Directive
-from sqlalchemy import create_engine, Table, MetaData, select, delete
 from runestone.server.componentdb import addQuestionToDB, addHTMLToDB
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 try:
     from html import escape  # py3
@@ -38,9 +35,9 @@ def setup(app):
     app.add_node(ExternalNode, html=(visit_external_node, depart_external_node))
 
 
-class ExternalNode(nodes.General, nodes.Element):
-    def __init__(self, content):
-        super(ExternalNode, self).__init__()
+class ExternalNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self, content, **kwargs):
+        super(ExternalNode, self).__init__(**kwargs)
         self.external_options = content
 
 
@@ -103,7 +100,7 @@ class ExternalDirective(RunestoneDirective):
 
         self.options['name'] = self.arguments[0].strip()
 
-        external_node = ExternalNode(self.options)
+        external_node = ExternalNode(self.options, rawsource=self.block_text)
         external_node.source, external_node.line = self.state_machine.get_source_and_line(self.lineno)
         self.add_name(external_node)
 

--- a/runestone/fitb/fitb.py
+++ b/runestone/fitb/fitb.py
@@ -68,8 +68,6 @@ def depart_fitb_node(self, node):
         blankCount += 1
 
     # Warn if there are fewer feedback items than blanks.
-    # TODO: node.source, node.line aren't defined.
-    #print(node.source, node.line)
     if len(node.feedbackArray) < blankCount:
         print('Warning at {} line {}: there'' not enough feedback for the number of blanks supplied.'.format(node.source, node.line))
 
@@ -137,8 +135,8 @@ class FillInTheBlank(RunestoneDirective):
 
         self.options['divid'] = self.arguments[0]
 
-        # TODO: How to include self.lineno in the directive?
         fitbNode = FITBNode(self.options)
+        fitbNode.source, fitbNode.line = self.state_machine.get_source_and_line(self.lineno)
         fitbNode.template_start = TEMPLATE_START
         fitbNode.template_end = TEMPLATE_END
 

--- a/runestone/livecode/livecode.py
+++ b/runestone/livecode/livecode.py
@@ -73,7 +73,9 @@ class LiveCode(Directive):
         template = env.get_template('livecode.html')
         output = template.render(**self.options)
 
-        return [nodes.raw('', output, format='html')]
+        raw_node = nodes.raw('', output, format='html')
+        raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
+        return [raw_node]
 
 
 

--- a/runestone/livecode/livecode.py
+++ b/runestone/livecode/livecode.py
@@ -18,10 +18,9 @@ __author__ = 'bmiller'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
-import json
 import os
 from jinja2 import Environment, FileSystemLoader
+from runestone.common.runestonedirective import RunestoneDirective
 
 # try:
 #     import conf
@@ -38,7 +37,7 @@ def setup(app):
     app.add_javascript('livecode.js')
     app.add_javascript('clike.js')
 
-class LiveCode(Directive):
+class LiveCode(RunestoneDirective):
     required_arguments = 1
     optional_arguments = 0
     has_content = True
@@ -73,7 +72,7 @@ class LiveCode(Directive):
         template = env.get_template('livecode.html')
         output = template.render(**self.options)
 
-        raw_node = nodes.raw('', output, format='html')
+        raw_node = nodes.raw(self.block_text, output, format='html')
         raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [raw_node]
 

--- a/runestone/meta/meta.py
+++ b/runestone/meta/meta.py
@@ -35,7 +35,9 @@ class Meta(Directive):
         :param self:
         :return:
         """
-        return [nodes.raw('','', format='html')]
+        raw_node = nodes.raw('','', format='html')
+        raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
+        return [raw_node]
 
 
 

--- a/runestone/meta/meta.py
+++ b/runestone/meta/meta.py
@@ -17,15 +17,14 @@ __author__ = 'bmiller'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
-
+from runestone.common.runestonedirective import RunestoneDirective
 
 def setup(app):
     app.add_directive('shortname',Meta)
     app.add_directive('description',Meta)
 
 
-class Meta(Directive):
+class Meta(RunestoneDirective):
     required_arguments = 1
     optional_arguments = 50
 
@@ -35,7 +34,7 @@ class Meta(Directive):
         :param self:
         :return:
         """
-        raw_node = nodes.raw('','', format='html')
+        raw_node = nodes.raw(self.block_text,'', format='html')
         raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [raw_node]
 

--- a/runestone/parsons/parsons.py
+++ b/runestone/parsons/parsons.py
@@ -15,13 +15,11 @@
 #
 __author__ = 'isaiahmayerchak'
 
-import re
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
 from runestone.assess import Assessment
 from runestone.server.componentdb import addQuestionToDB, addHTMLToDB
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 def setup(app):
     app.add_directive('parsonsprob', ParsonsProblem)
@@ -42,9 +40,9 @@ TEMPLATE = '''
         </div>
     '''
 
-class ParsonsNode(nodes.General, nodes.Element):
-    def __init__(self, options):
-        super(ParsonsNode, self).__init__()
+class ParsonsNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self, options, **kwargs):
+        super(ParsonsNode, self).__init__(**kwargs)
         self.parsonsnode_components = options
 
 def visit_parsons_node(self, node):
@@ -181,6 +179,6 @@ Example:
 
         self.assert_has_content()
 
-        parsons_node = ParsonsNode(self.options)
+        parsons_node = ParsonsNode(self.options, rawsource=self.block_text)
         parsons_node.source, parsons_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [parsons_node]

--- a/runestone/parsons/parsons.py
+++ b/runestone/parsons/parsons.py
@@ -142,7 +142,7 @@ Example:
         self.options['qnumber'] = self.getNumber()
         self.options['instructions'] = ""
         self.options['code'] = self.content
-        
+
         if 'maxdist' in self.options:
             self.options['maxdist'] = ' data-maxdist="' + self.options['maxdist'] + '"'
         else:
@@ -163,8 +163,8 @@ Example:
             self.options['language'] = ' data-language="' + self.options['language'] + '"'
         else:
             self.options['language'] = ''
-         
-          
+
+
         if '-----' in self.content:
             index = self.content.index('-----')
             self.options['instructions'] = "\n".join(self.content[:index])
@@ -181,4 +181,6 @@ Example:
 
         self.assert_has_content()
 
-        return [ParsonsNode(self.options)]
+        parsons_node = ParsonsNode(self.options)
+        parsons_node.source, parsons_node.line = self.state_machine.get_source_and_line(self.lineno)
+        return [parsons_node]

--- a/runestone/poll/poll.py
+++ b/runestone/poll/poll.py
@@ -136,5 +136,6 @@ class Poll(Directive):
         else:
             self.options["comment"] = ""
 
-
-        return [PollNode(self.options)]
+        poll_node = PollNode(self.options)
+        poll_node.source, poll_node.line = self.state_machine.get_source_and_line(self.lineno)
+        return [poll_node]

--- a/runestone/poll/poll.py
+++ b/runestone/poll/poll.py
@@ -18,7 +18,7 @@ __author__ = 'isaiahmayerchak'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 from runestone.server.componentdb import addQuestionToDB
 
 
@@ -41,14 +41,14 @@ TEMPLATE_OPTION = """
 
 TEMPLATE_END = """</ul>"""
 
-class PollNode(nodes.General, nodes.Element):
-    def __init__(self,content):
+class PollNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self,content, **kwargs):
         """
         Arguments:
         - `self`:
         - `content`:
         """
-        super(PollNode,self).__init__()
+        super(PollNode,self).__init__(**kwargs)
         self.poll_content = content
 
 # self for these functions is an instance of the writer class.  For example
@@ -80,7 +80,7 @@ def depart_poll_node(self,node):
     pass
 
 
-class Poll(Directive):
+class Poll(RunestoneDirective):
     """
 .. poll:: identifier
     :scale: Mode 1--Implements the "On a scale of 1 to x" type method of poll--x is provided by author
@@ -136,6 +136,6 @@ class Poll(Directive):
         else:
             self.options["comment"] = ""
 
-        poll_node = PollNode(self.options)
+        poll_node = PollNode(self.options, rawsource=self.block_text)
         poll_node.source, poll_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [poll_node]

--- a/runestone/question/question.py
+++ b/runestone/question/question.py
@@ -16,7 +16,7 @@
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 __author__ = 'bmiller'
 
@@ -27,9 +27,9 @@ def setup(app):
     app.add_node(QuestionNode, html=(visit_question_node, depart_question_node))
 
 
-class QuestionNode(nodes.General, nodes.Element):
-    def __init__(self, content):
-        super(QuestionNode, self).__init__()
+class QuestionNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self, content, **kwargs):
+        super(QuestionNode, self).__init__(**kwargs)
         self.question_options = content
 
 
@@ -92,7 +92,7 @@ class QuestionDirective(RunestoneDirective):
 
         self.options['name'] = self.arguments[0].strip()
 
-        question_node = QuestionNode(self.options)
+        question_node = QuestionNode(self.options, rawsource=self.block_text)
         question_node.source, question_node.line = self.state_machine.get_source_and_line(self.lineno)
         self.add_name(question_node)
 

--- a/runestone/question/question.py
+++ b/runestone/question/question.py
@@ -93,6 +93,7 @@ class QuestionDirective(RunestoneDirective):
         self.options['name'] = self.arguments[0].strip()
 
         question_node = QuestionNode(self.options)
+        question_node.source, question_node.line = self.state_machine.get_source_and_line(self.lineno)
         self.add_name(question_node)
 
         self.state.nested_parse(self.content, self.content_offset, question_node)

--- a/runestone/reveal/reveal.py
+++ b/runestone/reveal/reveal.py
@@ -17,8 +17,7 @@ __author__ = 'isaiahmayerchak'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 #add directives/javascript/css
 def setup(app):
@@ -28,9 +27,9 @@ def setup(app):
 
     app.add_node(RevealNode, html=(visit_reveal_node, depart_reveal_node))
 
-class RevealNode(nodes.General, nodes.Element):
-    def __init__(self,content):
-        super(RevealNode,self).__init__()
+class RevealNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self,content, **kwargs):
+        super(RevealNode,self).__init__(**kwargs)
         self.reveal_options = content
 
 
@@ -112,7 +111,7 @@ class RevealDirective(RunestoneDirective):
 
         self.options['divid'] = self.arguments[0]
 
-        reveal_node = RevealNode(self.options)
+        reveal_node = RevealNode(self.options, rawsource=self.block_text)
         reveal_node.source, reveal_node.line = self.state_machine.get_source_and_line(self.lineno)
 
         self.state.nested_parse(self.content, self.content_offset, reveal_node)

--- a/runestone/reveal/reveal.py
+++ b/runestone/reveal/reveal.py
@@ -113,6 +113,7 @@ class RevealDirective(RunestoneDirective):
         self.options['divid'] = self.arguments[0]
 
         reveal_node = RevealNode(self.options)
+        reveal_node.source, reveal_node.line = self.state_machine.get_source_and_line(self.lineno)
 
         self.state.nested_parse(self.content, self.content_offset, reveal_node)
 

--- a/runestone/server/chapternames.py
+++ b/runestone/server/chapternames.py
@@ -25,7 +25,8 @@ def unCamel(x):
 
 
 def findChaptersSubChapters(tocfile):
-    ftext = open(tocfile, 'r').readlines()
+    with open(tocfile, 'r') as f:
+        ftext = f.readlines()
     if '.. toc_version: 2\n' in ftext:
         return findV2ChaptersSubChapters(tocfile)
 
@@ -52,7 +53,8 @@ def findChaptersSubChapters(tocfile):
     return chdict, chtitles
 
 def findV2ChaptersSubChapters(tocfile):
-    ftext = open(tocfile, 'r').readlines()
+    with open(tocfile, 'r') as f:
+        ftext = f.readlines()
     # Find the the toctree directive
     # then make a list of all of the sub entries in the toctree
     # If the line has a  / in it then it is a chapter we can deal with

--- a/runestone/shortanswer/shortanswer.py
+++ b/runestone/shortanswer/shortanswer.py
@@ -83,5 +83,6 @@ class JournalDirective(Assessment):
         self.options['content'] = "<p>".join(self.content)
         self.options['qnum'] = self.getNumber()
         journal_node = JournalNode(self.options)
+        journal_node.source, journal_node.line = self.state_machine.get_source_and_line(self.lineno)
 
         return [journal_node]

--- a/runestone/shortanswer/shortanswer.py
+++ b/runestone/shortanswer/shortanswer.py
@@ -15,14 +15,12 @@
 #
 __author__ = 'isaiahmayerchak'
 #acbart did most of this code, I mostly just changed the template
-import os
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
 from runestone.assess import Assessment
 from runestone.server.componentdb import addQuestionToDB, addHTMLToDB
-from runestone.common.runestonedirective import RunestoneDirective
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 def setup(app):
     app.add_directive('shortanswer', JournalDirective)
@@ -37,9 +35,9 @@ TEXT = """
 </div>
 """
 
-class JournalNode(nodes.General, nodes.Element):
-    def __init__(self, options):
-        super(JournalNode, self).__init__()
+class JournalNode(nodes.General, nodes.Element, RunestoneNode):
+    def __init__(self, options, **kwargs):
+        super(JournalNode, self).__init__(**kwargs)
         self.journalnode_components = options
 
 def visit_journal_node(self, node):
@@ -82,7 +80,7 @@ class JournalDirective(Assessment):
         self.options['divid'] = self.arguments[0]
         self.options['content'] = "<p>".join(self.content)
         self.options['qnum'] = self.getNumber()
-        journal_node = JournalNode(self.options)
+        journal_node = JournalNode(self.options, rawsource=self.block_text)
         journal_node.source, journal_node.line = self.state_machine.get_source_and_line(self.lineno)
 
         return [journal_node]

--- a/runestone/tabbedStuff/tabbedStuff.py
+++ b/runestone/tabbedStuff/tabbedStuff.py
@@ -17,7 +17,7 @@ __author__ = 'isaiahmayerchak'
 
 from docutils import nodes
 from docutils.parsers.rst import directives
-from docutils.parsers.rst import Directive
+from runestone.common.runestonedirective import RunestoneDirective, RunestoneNode
 
 def setup(app):
 #Add directives/javascript/css
@@ -45,8 +45,8 @@ END = """
 """
 
 class TabNode(nodes.General, nodes.Element):
-    def __init__(self, content):
-        super(TabNode, self).__init__()
+    def __init__(self, content, **kwargs):
+        super(TabNode, self).__init__(**kwargs)
         self.tabnode_options = content
         self.tabname = content['tabname']
 
@@ -69,7 +69,7 @@ def depart_tab_node(self,node):
 #Set options and format templates accordingly
     self.body.append(TABDIV_END)
 
-class TabbedStuffNode(nodes.General, nodes.Element):
+class TabbedStuffNode(nodes.General, nodes.Element, RunestoneNode):
     '''A TabbedStuffNode contains one or more TabNodes'''
     def __init__(self,content):
         super(TabbedStuffNode,self).__init__()
@@ -101,7 +101,7 @@ def depart_tabbedstuff_node(self,node):
 
 
 
-class TabDirective(Directive):
+class TabDirective(RunestoneDirective):
     """
 .. tab:: identifier
    :active: Optional flag that specifies this tab to be opened when page is loaded (default is first tab)--overridden by :inactive: flag on tabbedStuff
@@ -139,7 +139,7 @@ class TabDirective(Directive):
         self.state.nested_parse(self.content, self.content_offset, tab_node)
         return [tab_node]
 
-class TabbedStuffDirective(Directive):
+class TabbedStuffDirective(RunestoneDirective):
     """
 .. tabbed:: identifier
    :inactive: Optional flag that calls for no tabs to be open on page load
@@ -172,7 +172,7 @@ class TabbedStuffDirective(Directive):
         self.options['divid'] = self.arguments[0]
 
         # Create the node, to be populated by "nested_parse".
-        tabbedstuff_node = TabbedStuffNode(self.options)
+        tabbedstuff_node = TabbedStuffNode(self.options, rawsource=self.block_text)
         tabbedstuff_node.source, tabbedstuff_node.line = self.state_machine.get_source_and_line(self.lineno)
 
         # Parse the directive contents (should be 1 or more tab directives)

--- a/runestone/tabbedStuff/tabbedStuff.py
+++ b/runestone/tabbedStuff/tabbedStuff.py
@@ -173,6 +173,7 @@ class TabbedStuffDirective(Directive):
 
         # Create the node, to be populated by "nested_parse".
         tabbedstuff_node = TabbedStuffNode(self.options)
+        tabbedstuff_node.source, tabbedstuff_node.line = self.state_machine.get_source_and_line(self.lineno)
 
         # Parse the directive contents (should be 1 or more tab directives)
         self.state.nested_parse(self.content, self.content_offset, tabbedstuff_node)

--- a/runestone/unittest_base.py
+++ b/runestone/unittest_base.py
@@ -45,9 +45,12 @@ def module_fixture_maker(module_path):
 # Provide a base test case which sets up the `Selenium <http://selenium-python.readthedocs.io/>`_ driver.
 class RunestoneTestCase(unittest.TestCase):
     def setUp(self):
-
-        self.display = Display(visible=0, size=(1280, 1024))
-        self.display.start()
+        # `PyVirtualDisplay <http://pyvirtualdisplay.readthedocs.io/en/latest/>`_ only runs on X-windows, meaning Linux. Mac seems to have `some support <https://support.apple.com/en-us/HT201341>`_. Windows is out of the question.
+        if os.name != 'nt':
+            self.display = Display(visible=0, size=(1280, 1024))
+            self.display.start()
+        else:
+            self.display = None
         #self.driver = webdriver.PhantomJS() # use this for Jenkins auto testing
         # options = webdriver.ChromeOptions()
         # options.add_argument("headless")
@@ -60,4 +63,5 @@ class RunestoneTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.driver.quit()
-        self.display.stop()
+        if self.display:
+            self.display.stop()

--- a/runestone/usageAssignment/__init__.py
+++ b/runestone/usageAssignment/__init__.py
@@ -242,4 +242,6 @@ class usageAssignment(Directive):
             q_id = getOrInsertQuestionForPage(base_course=basecourse_name, name=acid, is_private='F', question_type="page", autograde = "visited", difficulty=1,chapter=None)
             addAssignmentQuestionToDB(q_id, assignment_id, 1, autograde="visited")
 
-        return [usageAssignmentNode(self.options)]
+        usage_assignment_node = usageAssignmentNode(self.options)
+        usage_assignment_node.source, usage_assignment_node.line = self.state_machine.get_source_and_line(self.lineno)
+        return [usage_assignment_node]

--- a/runestone/video/video.py
+++ b/runestone/video/video.py
@@ -128,7 +128,7 @@ class Video(RunestoneDirective):
             res += INLINE % self.options
 
         addHTMLToDB(self.options['divid'], self.options['basecourse'], res)
-        return [nodes.raw('',res , format='html')]
+        return [nodes.raw(self.block_text, res, format='html')]
 
 
 """
@@ -177,7 +177,7 @@ class IframeVideo(Directive):
             self.options['height'] = self.default_height
         if not self.options.get('align'):
             self.options['align'] = 'left'
-        raw_node = nodes.raw('', self.html % self.options, format='html')
+        raw_node = nodes.raw(self.block_text, self.html % self.options, format='html')
         raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [raw_node]
 

--- a/runestone/video/video.py
+++ b/runestone/video/video.py
@@ -177,7 +177,9 @@ class IframeVideo(Directive):
             self.options['height'] = self.default_height
         if not self.options.get('align'):
             self.options['align'] = 'left'
-        return [nodes.raw('', self.html % self.options, format='html')]
+        raw_node = nodes.raw('', self.html % self.options, format='html')
+        raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
+        return [raw_node]
 
 
 class Youtube(IframeVideo):


### PR DESCRIPTION
- Get Selenium tests working on Windows after updates.
- Fix a test failure on Windows/Chrome.
- Include source and line number info in every top-level Runestone node. This improves reST's ability to report line number of errors.