### PR TITLE
Misc fixes

### DIFF
--- a/runestone/assess/js/mchoice.js
+++ b/runestone/assess/js/mchoice.js
@@ -294,6 +294,11 @@ MultipleChoice.prototype.restoreAnswers = function (data) {
             }
         }
     }
+    if (this.multipleanswers) {
+        this.processMCMASubmission(false);
+    } else {
+        this.processMCMFSubmission(false);
+    }
 };
 
 MultipleChoice.prototype.checkLocalStorage = function () {

--- a/runestone/assess/test/_sources/index.rst
+++ b/runestone/assess/test/_sources/index.rst
@@ -26,22 +26,21 @@ New style
 
     Which colors might be found in a rainbow (check all)?
 
-    -   Cred
+    -   red
 
-        -   Red it is.
+        +   Red it is.
 
     -   brown
 
         -   Not brown.
 
-    -   Cblue
+    -   blue
 
-        -   Blue it is.
+        +   Blue it is.
 
     -   gray
 
         -   Not gray.
-
 
 Test error handling
 ^^^^^^^^^^^^^^^^^^^
@@ -55,9 +54,9 @@ Test error handling
 
     A list with missing sublists.
 
-    -   COne
+    -   One
 
-        -   Yes.
+        +   Yes.
 
     -   Two
 
@@ -66,22 +65,22 @@ Test error handling
 
     A list with extra sublists.
 
-    -   COne
+    -   One
 
-        -   Yes.
-        -   OK.
+        +   Yes.
+        +   OK.
 
     -   Two
 
         -   No.
 
-.. This just produces a confused question. The auto-numbering in the base classes prepends ``Q-x`` to ``-   COne``, which means it's no longer a list. There's no easy way to detect this, without rewriting the way question numbers are prepended.
+.. This just produces a confused question. The auto-numbering in the base classes prepends ``Q-x`` to ``-   One``, which means it's no longer a list. There's no easy way to detect this, without rewriting the way question numbers are prepended.
 
     .. mchoice:: error5_only_list_is_provided
 
-        -   COne
+        -   One
 
-            -   Yes.
+            +   Yes.
 
         -   Two
 
@@ -91,13 +90,13 @@ Test error handling
 
     A list with something else instead of sublists.
 
-    -   COne
+    -   One
 
         Not a sublist.
 
     -   Two
 
-        -   No
+        +   No
 
 
 .. mchoice:: error7
@@ -113,8 +112,9 @@ Test error handling
         -   Nope.
 
 Multiple Choice
----------------
-
+===============
+Old style
+---------
 .. mchoice:: question2
     :correct: a
     :answer_a: red
@@ -126,4 +126,27 @@ Multiple Choice
     :feedback_c: Not black.
     :feedback_d: Not gray.
 
-    Which color might be found in a rainbow?
+    What color is a stop sign?
+
+New style
+---------
+.. mchoice:: question2_new
+
+    What color is a stop sign?
+
+    -   red
+
+        +   Red it is.
+
+    -   brown
+
+        -   Not brown.
+
+    -   blue
+
+        -   Not blue.
+
+    -   gray
+
+        -   Not gray.
+

--- a/runestone/assess/test/test_assess.py
+++ b/runestone/assess/test/test_assess.py
@@ -15,11 +15,11 @@ class MultipleChoiceQuestion_Error_Tests(TestCase):
         # Check for the following directive-level errors.
         directive_level_errors =  (
             # Produced my mchoice id: error1_no_content,
-            (48, 'No correct answer specified'),
+            (47, 'No correct answer specified'),
             # error2,
-            (50, 'No correct answer specified.'),
+            (49, 'No correct answer specified.'),
             # error7,
-            (103, 'No correct answer specified.'),
+            (102, 'No correct answer specified.'),
         )
         for error_line, error_string in directive_level_errors:
             # The rst_prolog in conf.py confuses line numbers. Adjust for it.
@@ -28,11 +28,11 @@ class MultipleChoiceQuestion_Error_Tests(TestCase):
         # Check for the following error inside the directive.
         inside_directive_lines = (
             # Produced my mchoice id error3,
-            62,
+            61,
             # error4,
-            71,
+            70,
             # error6
-            96,
+            95,
         )
         for error_line in inside_directive_lines:
             # The rst_prolog in conf.py confuses line numbers. Adjust for it.

--- a/runestone/fitb/js/fitb.js
+++ b/runestone/fitb/js/fitb.js
@@ -127,6 +127,7 @@ FITB.prototype.restoreAnswers = function (data) {
     for (var i = 0; i < this.blankArray.length; i++) {
         $(this.blankArray[i]).attr("value", arr[i]);
     }
+    this.startEvaluation();
 };
 
 FITB.prototype.checkLocalStorage = function () {


### PR DESCRIPTION
Two fixes:

- Make mchoice questions easier to write: use a + for the bullet style of feedback to indicate it's the correct answer. Easier for authors, cleaner code, less messy editing of rest text (used to remove a C or +, which can lead to side effects).
- Have (at least some -- fitb and mchoice) questions tell students if their answers were correct or not when re-visiting a page. Makes it much easier to work on assignments -- they know what's done and what's not yet done.