### PR TITLE
Begin Development of ShowEval v2

### DIFF
--- a/runestone/showeval/showeval.py
+++ b/runestone/showeval/showeval.py
@@ -27,11 +27,11 @@ def setup(app):
     app.add_stylesheet('showEval.css')
 
 CODE = """\
-<div data-childcomponent="showeval" class="runestone explainer alert alert-warning">
+<div data-childcomponent="showeval" data-optional="%(trace_mode)s" class="runestone explainer alert alert-warning">
     <button class="btn btn-success" id="%(divid)s_nextStep">Next Step</button>
     <button class="btn btn-default" id ="%(divid)s_reset">Reset</button>
     <div class="evalCont" style="background-color: #FDFDFD;">%(preReqLines)s</div>
-    <div class="evalCont" id="%(divid)s"></div>
+    <div class="evalCont" id="%(divid)s">%(steps)s</div>
 </div>
 """
 
@@ -96,21 +96,22 @@ class ShowEval(RunestoneDirective):
         self.options['divid'] = self.arguments[0]
         self.options['trace_mode'] = self.options['trace_mode'].lower()
         self.options['preReqLines'] = ''
-        self.options['steps'] = []
+        self.options['steps'] = "<ul>\n"
 
         step = False
         count = 0
         for line in self.content:
             if step == True:
                 if line != '':
-                    self.options['steps'].append(str(line))
+                    self.options['steps'] += "<li>" + str(line) + "</li>\n"
             elif '~~~~' in line:
                 step = True
             else:
                 self.options['preReqLines'] += line + '<br />\n'
 
+        self.options['steps'] += "</ul>"
 
-        res = (CODE + SCRIPT) % self.options
+        res = (CODE) % self.options
 
         addHTMLToDB(self.options['divid'], self.options['basecourse'], res)
         return [nodes.raw(self.block_text, res, format='html')]

--- a/runestone/showeval/test/_sources/replace.rst
+++ b/runestone/showeval/test/_sources/replace.rst
@@ -12,7 +12,7 @@ ShowEval Replace Mode
    ~~~~
 
    ''.join({{eggs}}{{['dogs', 'cats', 'moose']}}).upper().join(eggs)
-   {{''.join(['dogs', 'cats', 'moose'])}}{{'dogscatsmoose'}}.upper().join(eggs)
+   {{''.join(['dogs', 'cats', 'moose'])}}{{'dogscatsmoose'}}.upper().join(eggs)  ##This is a test Comment.
    {{'dogscatsmoose'.upper()}}{{'DOGSCATSMOOSE'}}.join(eggs)
    'DOGSCATSMOOSE'.join({{eggs}}{{['dogs', 'cats', 'moose']}})
    {{'DOGSCATSMOOSE'.join(['dogs', 'cats', 'moose'])}}{{'dogsDOGSCATSMOOSEcatsDOGSCATSMOOSEmoose'}}

--- a/runestone/showeval/test/_sources/trace.rst
+++ b/runestone/showeval/test/_sources/trace.rst
@@ -12,7 +12,7 @@ ShowEval Trace Mode
    ~~~~
 
    ''.join({{eggs}}{{['dogs', 'cats', 'moose']}}).upper().join(eggs)
-   {{''.join(['dogs', 'cats', 'moose'])}}{{'dogscatsmoose'}}.upper().join(eggs)
+   {{''.join(['dogs', 'cats', 'moose'])}}{{'dogscatsmoose'}}.upper().join(eggs)  ##This is a test Comment.
    {{'dogscatsmoose'.upper()}}{{'DOGSCATSMOOSE'}}.join(eggs)
    'DOGSCATSMOOSE'.join({{eggs}}{{['dogs', 'cats', 'moose']}})
    {{'DOGSCATSMOOSE'.join(['dogs', 'cats', 'moose'])}}{{'dogsDOGSCATSMOOSEcatsDOGSCATSMOOSEmoose'}}

--- a/runestone/showeval/test/test_showEval.py
+++ b/runestone/showeval/test/test_showEval.py
@@ -38,6 +38,24 @@ class ShowEvalTest_TraceMode(unittest.TestCase):
         driver.find_element_by_id("showEval_0_reset").click()
         assert len(evalDiv.find_elements_by_class_name("previousStep")) == 0
 
+    def test_Comment(self):
+        driver = self.driver
+        self.assertIn("ShowEval", driver.title)
+        evalDiv = driver.find_element_by_id("showEval_0")
+        commentDiv = evalDiv.find_element_by_class_name("anno")
+
+        assert commentDiv.is_displayed() == False
+
+        driver.find_element_by_id("showEval_0_nextStep").click()
+        time.sleep(4)
+
+        assert commentDiv.is_displayed() == True
+
+        driver.find_element_by_id("showEval_0_nextStep").click()
+        time.sleep(4)
+
+        assert commentDiv.is_displayed() == False
+
     def tearDown(self):
         self.driver.close()
 
@@ -74,6 +92,24 @@ class ShowEvalTest_ReplaceMode(unittest.TestCase):
         assert driver.find_element_by_class_name("eval").text != evalText1
         driver.find_element_by_id("showEval_0_reset").click()
         assert driver.find_element_by_class_name("eval").text == evalText1
+
+    def test_Comment(self):
+        driver = self.driver
+        self.assertIn("ShowEval", driver.title)
+        evalDiv = driver.find_element_by_id("showEval_0")
+        commentDiv = evalDiv.find_element_by_class_name("anno")
+
+        assert commentDiv.is_displayed() == False
+
+        driver.find_element_by_id("showEval_0_nextStep").click()
+        time.sleep(4)
+
+        assert commentDiv.is_displayed() == True
+
+        driver.find_element_by_id("showEval_0_nextStep").click()
+        time.sleep(4)
+
+        assert commentDiv.is_displayed() == False
 
     def tearDown(self):
         self.driver.close()


### PR DESCRIPTION
Things to do:

- [x] The steps would be embedded into the div either as a variable or as a `<ul>` with `<li>` entries for each step.  
- [ ] The ShowEval constructor would just take the `divid` as the parameter — which is what the others do too.  
- [ ] The trace value would become an attribute of the outter `<div>`  
- [ ] Remove `<script>` tag from HTML doc
- [ ] The constructor would be modified to call the `setNextButton()` on this rather than from the script