### PR TITLE
Deprecating assignment and usageassignment directives

### DIFF
--- a/runestone/assignment/__init__.py
+++ b/runestone/assignment/__init__.py
@@ -104,53 +104,53 @@ class Assignment(RunestoneDirective):
 
         course_name = self.state.document.settings.env.config.html_context['course_id']
         self.options['course_name'] = course_name
-        course_id = getCourseID(course_name)
-        basecourse_name = self.state.document.settings.env.config.html_context.get('basecourse', "unknown")
-        self.options['basecourse'] = self.state.document.settings.env.config.html_context.get('basecourse', "unknown")
+
+        ## No longer doing DB operations
+        # course_id = getCourseID(course_name)
+        # basecourse_name = self.state.document.settings.env.config.html_context.get('basecourse', "unknown")
+        # self.options['basecourse'] = self.state.document.settings.env.config.html_context.get('basecourse', "unknown")
 
         name = self.options.get('name') # required; error if missing
-        assignment_type_name = self.options.get('assignment_type')
-        assignment_type_id = getOrCreateAssignmentType(assignment_type_name)
-
-        deadline = None
-
-        if 'deadline' in self.options:
-            try:
-                deadline = datetime.strptime(self.options['deadline'], '%Y-%m-%d %H:%M')
-            except:
-                try:
-                    deadline = datetime.strptime(self.options['deadline'], '%Y-%m-%d %H:%M:%S')
-                    self.state.document.settings.env.warn(self.state.document.settings.env.docname, "deadline not in preferred format %Y-%m-%d %H:%M but accepting alternate format with seconds")
-                except:
-                    self.state.document.settings.env.warn(self.state.document.settings.env.docname, "deadline missing or incorrectly formatted; Omitting deadline")
-
-        points = self.options.get('points', 0)
-        threshold = self.options.get('threshold', None)
-        if threshold:
-            threshold = int(threshold)
-        autograde = self.options.get('autograde', None)
-
-        assignment_id = addAssignmentToDB(name = name,
-                          course_id = course_id,
-                          assignment_type_id = assignment_type_id,
-                          deadline = deadline,
-                          points = points,
-                          threshold = threshold)
+        # assignment_type_name = self.options.get('assignment_type')
+        # assignment_type_id = getOrCreateAssignmentType(assignment_type_name)
+        #
+        # deadline = None
+        #
+        # if 'deadline' in self.options:
+        #     try:
+        #         deadline = datetime.strptime(self.options['deadline'], '%Y-%m-%d %H:%M')
+        #     except:
+        #         try:
+        #             deadline = datetime.strptime(self.options['deadline'], '%Y-%m-%d %H:%M:%S')
+        #             self.state.document.settings.env.warn(self.state.document.settings.env.docname, "deadline not in preferred format %Y-%m-%d %H:%M but accepting alternate format with seconds")
+        #         except:
+        #             self.state.document.settings.env.warn(self.state.document.settings.env.docname, "deadline missing or incorrectly formatted; Omitting deadline")
+        #
+        # points = self.options.get('points', 0)
+        # threshold = self.options.get('threshold', None)
+        # if threshold:
+        #     threshold = int(threshold)
+        # autograde = self.options.get('autograde', None)
+        #
+        # assignment_id = addAssignmentToDB(name = name,
+        #                   course_id = course_id,
+        #                   assignment_type_id = assignment_type_id,
+        #                   deadline = deadline,
+        #                   points = points)
 
         unparsed = self.options.get('questions', None)
         question_names = []
         if unparsed:
-            summative_type_id = getOrCreateAssignmentType("summative")
             q_strings = unparsed.split(',')
             for q in q_strings:
                 (question_name, points) = q.strip().split()
                 question_names.append(question_name)
                 # first get the question_id associated with question_name
-                question_id = getQuestionID(basecourse_name, question_name)
-                if question_id:
-                    addAssignmentQuestionToDB(question_id, assignment_id, points, assessment_type = summative_type_id, autograde = autograde)
-                else:
-                    self.state.document.settings.env.warn(self.state.document.settings.env.docname, "Question {} is not in the database for basecourse {}".format(question_name, basecourse_name))
+                # question_id = getQuestionID(basecourse_name, question_name)
+                # if question_id:
+                #     addAssignmentQuestionToDB(question_id, assignment_id, points, autograde = autograde)
+                # else:
+                #     self.state.document.settings.env.warn(self.state.document.settings.env.docname, "Question {} is not in the database for basecourse {}".format(question_name, basecourse_name))
         else:
             self.state.document.settings.env.warn(self.state.document.settings.env.docname, "No questions for assignment {}".format(name))
         self.options['question_ids'] = question_names

--- a/runestone/server/componentdb.py
+++ b/runestone/server/componentdb.py
@@ -62,9 +62,6 @@ def addQuestionToDB(self):
 
         last_changed = datetime.now()
 
-        engine = create_engine(dburl)
-        meta = MetaData()
-        questions = Table('questions', meta, autoload=True, autoload_with=engine)
         if 'difficulty' in self.options:
             difficulty = self.options['difficulty']
         else:
@@ -96,9 +93,6 @@ question_type=self.name, subchapter=subchapter, autograde = autograde, author=au
             raise self.severe("Bad character in directive {} in {}/{} this will not be saved to the DB".format(self.arguments[0], self.chapter, self.subchapter))
 
 def getQuestionID(base_course, name):
-    meta = MetaData()
-    questions = Table('questions', meta, autoload=True, autoload_with=engine)
-
 
     sel = select([questions]).where(and_(questions.c.name == name,
                                           questions.c.base_course == base_course))
@@ -110,10 +104,6 @@ def getQuestionID(base_course, name):
 
 def getOrInsertQuestionForPage(base_course=None, name=None, is_private='F', question_type="page", autograde = "visited", author=None, difficulty=1,chapter=None):
     last_changed = datetime.now()
-
-    meta = MetaData()
-    questions = Table('questions', meta, autoload=True, autoload_with=engine)
-
 
     sel = select([questions]).where(and_(questions.c.name == name,
                                           questions.c.base_course == base_course))
@@ -147,8 +137,6 @@ def getOrInsertQuestionForPage(base_course=None, name=None, is_private='F', ques
 
 def getOrCreateAssignmentType(assignment_type_name, grade_type = None, points_possible = None, assignments_count = None, assignments_dropped = None):
 
-    meta = MetaData()
-    assignment_types = Table('assignment_types', meta, autoload=True, autoload_with=engine)
 
     # search for it in the DB
     sel = select([assignment_types]).where(assignment_types.c.name == assignment_type_name)
@@ -167,9 +155,6 @@ def getOrCreateAssignmentType(assignment_type_name, grade_type = None, points_po
         return res.inserted_primary_key[0]
 
 def addAssignmentQuestionToDB(question_id, assignment_id, points, activities_required = 0, autograde=None, which_to_grade = None, reading_assignment=None, sorting_priority=0):
-    meta = MetaData()
-    assignment_questions = Table('assignment_questions', meta, autoload=True, autoload_with=engine)
-
     # now insert or update the assignment_questions row
     sel = select([assignment_questions]).where(and_(assignment_questions.c.assignment_id == assignment_id,
                                           assignment_questions.c.question_id == question_id))
@@ -193,9 +178,6 @@ def addAssignmentQuestionToDB(question_id, assignment_id, points, activities_req
         engine.execute(ins)
 
 def getCourseID(coursename):
-    meta = MetaData()
-    courses = Table('courses', meta, autoload=True, autoload_with=engine)
-
     sel = select([courses]).where(courses.c.course_name == coursename)
     res = engine.execute(sel).first()
     return res['id']
@@ -203,11 +185,6 @@ def getCourseID(coursename):
 def addAssignmentToDB(name = None, course_id = None, assignment_type_id = None, deadline = None, points = None):
 
     last_changed = datetime.now()
-
-    meta = MetaData()
-    assignments = Table('assignments', meta, autoload=True, autoload_with=engine)
-    assignment_questions = Table('assignment_questions', meta, autoload=True, autoload_with=engine)
-
     sel = select([assignments]).where(and_(assignments.c.name == name,
                                           assignments.c.course == course_id))
     res = engine.execute(sel).first()
@@ -239,9 +216,6 @@ def addAssignmentToDB(name = None, course_id = None, assignment_type_id = None, 
 def addHTMLToDB(divid, basecourse, htmlsrc):
     if dburl:
         last_changed = datetime.now()
-        engine = create_engine(dburl)
-        meta = MetaData()
-        questions = Table('questions', meta, autoload=True, autoload_with=engine)
         sel = select([questions]).where(and_(questions.c.name == divid,
                                               questions.c.base_course == basecourse))
         res = engine.execute(sel).first()
@@ -256,8 +230,6 @@ def addHTMLToDB(divid, basecourse, htmlsrc):
             print("Error while trying to add directive {} to the DB".format(divid))
 
 def get_HTML_from_DB(divid, basecourse):
-    meta = MetaData()
-    questions = Table('questions', meta, autoload=True, autoload_with=engine)
     sel = select([questions]).where(and_(questions.c.name == divid,
                                           questions.c.base_course == basecourse))
     res = engine.execute(sel).first()

--- a/runestone/usageAssignment/__init__.py
+++ b/runestone/usageAssignment/__init__.py
@@ -148,22 +148,22 @@ class usageAssignment(RunestoneDirective):
 
         Chapter = Table('chapters', meta, autoload=True, autoload_with=engine)
         SubChapter = Table('sub_chapters', meta, autoload=True, autoload_with=engine)
-        Problem = Table('problems', meta, autoload=True, autoload_with=engine)
-        Div = Table('div_ids', meta, autoload=True, autoload_with=engine)
-        AssignmentType = Table('assignment_types', meta, autoload=True, autoload_with=engine)
-        Section = Table('sections', meta, autoload=True, autoload_with=engine)
+        # Problem = Table('problems', meta, autoload=True, autoload_with=engine)
+        # Questions = Table('questions', meta, autoload=True, autoload_with=engine)
+        # AssignmentType = Table('assignment_types', meta, autoload=True, autoload_with=engine)
+        # Section = Table('sections', meta, autoload=True, autoload_with=engine)
 
-        assignment_type_id = getOrCreateAssignmentType("Lecture Prep",
-                                  grade_type = 'use',
-                                  points_possible = '50',
-                                  assignments_count = 23,
-                                  assignments_dropped = 3)
+        # assignment_type_id = getOrCreateAssignmentType("Lecture Prep",
+        #                           grade_type = 'use',
+        #                           points_possible = '50',
+        #                           assignments_count = 23,
+        #                           assignments_dropped = 3)
 
 
         course_name = self.state.document.settings.env.config.html_context['course_id']
         self.options['course_name'] = course_name
-        course_id = getCourseID(course_name)
-        basecourse_name = self.state.document.settings.env.config.html_context.get('basecourse', "unknown")
+        # course_id = getCourseID(course_name)
+        # basecourse_name = self.state.document.settings.env.config.html_context.get('basecourse', "unknown")
 
         # Accumulate all the Chapters and SubChapters that are to be visited
         # For each chapter, accumulate all subchapters
@@ -198,48 +198,45 @@ class usageAssignment(RunestoneDirective):
                 self.state.document.settings.env.warn(self.state.document.settings.env.docname, "Subchapters requested not found: %s" % (self.options.get('subchapters')))
 
         # Accumulate all the ActiveCodes that are to be run and URL paths to be visited
-        divs = []
-        paths = []
-        for subch in sub_chs:
-            try:
-                ch_name = session.query(Chapter).filter(Chapter.c.id == subch.chapter_id).first().chapter_label
-                divs += session.query(Div).filter(Div.c.course_name == course_name,
-                                                  Div.c.chapter == ch_name,
-                                                  Div.c.subchapter == subch.sub_chapter_label).all()
-                paths.append('/runestone/static/%s/%s/%s.html' % (course_name, ch_name, subch.sub_chapter_label))
-            except:
-                self.state.document.settings.env.warn(self.state.document.settings.env.docname, "Subchapter not found: %s" % (subch))
-        tracked_div_types = ['activecode', 'actex']
-        active_codes = [d.div_id for d in divs if d.div_type in tracked_div_types]
+        # questions = []
+        # paths = []
+        # for subch in sub_chs:
+        #     try:
+        #         ch_name = session.query(Chapter).filter(Chapter.c.id == subch.chapter_id).first().chapter_label
+        #         questions += session.query(Questions).filter(Questions.c.base_course == basecourse_name,
+        #                                           Questions.c.chapter == ch_name,
+        #                                           Questions.c.subchapter == subch.sub_chapter_label).all()
+        #         paths.append('/runestone/static/%s/%s/%s.html' % (course_name, ch_name, subch.sub_chapter_label))
+        #     except:
+        #         self.state.document.settings.env.warn(self.state.document.settings.env.docname, "Subchapter not found: %s" % (subch))
+        # # tracked_q_types = ['activecode', 'actex']
+        # active_codes = [d.name for d in questions if d.question_type in tracked_q_types]
 
+        # min_activities = (len(paths) + len(active_codes)) * self.options.get('pct_required', 0) / 100
+        #
+        # deadline = None
+        # if 'deadline' in self.options:
+        #     try:
+        #         deadline = datetime.strptime(self.options['deadline'], '%Y-%m-%d %H:%M')
+        #     except:
+        #         try:
+        #             deadline = datetime.strptime(self.options['deadline'], '%Y-%m-%d %H:%M:%S')
+        #             self.state.document.settings.env.warn(self.state.document.settings.env.docname, "deadline not in preferred format %Y-%m-%d %H:%M but accepting alternate format with seconds")
+        #         except:
+        #             self.state.document.settings.env.warn(self.state.document.settings.env.docname, "deadline missing or incorrectly formatted; Omitting deadline")
+        #
+        # points = self.options.get('points', 0)
 
+        # assignment_id = addAssignmentToDB(name = self.options.get('assignment_name', 'dummy_assignment'),
+        #                   course_id = course_id,
+        #                   assignment_type_id = assignment_type_id,
+        #                   deadline = deadline,
+        #                   points = points)
 
-        min_activities = (len(paths) + len(active_codes)) * self.options.get('pct_required', 0) / 100
-
-        deadline = None
-        if 'deadline' in self.options:
-            try:
-                deadline = datetime.strptime(self.options['deadline'], '%Y-%m-%d %H:%M')
-            except:
-                try:
-                    deadline = datetime.strptime(self.options['deadline'], '%Y-%m-%d %H:%M:%S')
-                    self.state.document.settings.env.warn(self.state.document.settings.env.docname, "deadline not in preferred format %Y-%m-%d %H:%M but accepting alternate format with seconds")
-                except:
-                    self.state.document.settings.env.warn(self.state.document.settings.env.docname, "deadline missing or incorrectly formatted; Omitting deadline")
-
-        points = self.options.get('points', 0)
-
-        assignment_id = addAssignmentToDB(name = self.options.get('assignment_name', 'dummy_assignment'),
-                          course_id = course_id,
-                          assignment_type_id = assignment_type_id,
-                          deadline = deadline,
-                          points = points,
-                          threshold = min_activities)
-
-        for acid in paths + active_codes:
-            q_id = getOrInsertQuestionForPage(base_course=basecourse_name, name=acid, is_private='F', question_type="page", autograde = "visited", difficulty=1,chapter=None)
-            ## Associate the question with the assignment, by adding a row to the assignment_questions table
-            addAssignmentQuestionToDB(q_id, assignment_id, 1, autograde="visited", reading_assignment='T')
+        # for acid in paths + active_codes:
+        #     q_id = getOrInsertQuestionForPage(base_course=basecourse_name, name=acid, is_private='F', question_type="page", autograde = "visited", difficulty=1,chapter=None)
+        #     ## Associate the question with the assignment, by adding a row to the assignment_questions table
+        #     addAssignmentQuestionToDB(q_id, assignment_id, 1, autograde="visited", reading_assignment='T', )
 
         usage_assignment_node = usageAssignmentNode(self.options, rawsource=self.block_text)
         usage_assignment_node.source, usage_assignment_node.line = self.state_machine.get_source_and_line(self.lineno)

--- a/runestone/usageAssignment/__init__.py
+++ b/runestone/usageAssignment/__init__.py
@@ -238,7 +238,8 @@ class usageAssignment(RunestoneDirective):
 
         for acid in paths + active_codes:
             q_id = getOrInsertQuestionForPage(base_course=basecourse_name, name=acid, is_private='F', question_type="page", autograde = "visited", difficulty=1,chapter=None)
-            addAssignmentQuestionToDB(q_id, assignment_id, 1, autograde="visited")
+            ## Associate the question with the assignment, by adding a row to the assignment_questions table
+            addAssignmentQuestionToDB(q_id, assignment_id, 1, autograde="visited", reading_assignment='T')
 
         usage_assignment_node = usageAssignmentNode(self.options, rawsource=self.block_text)
         usage_assignment_node.source, usage_assignment_node.line = self.state_machine.get_source_and_line(self.lineno)


### PR DESCRIPTION
Keeping the directives for backward compatibility, but removing the DB operations that they did. May revive these at some point, but for now, instructors will have to use the web interface only.