### PR TITLE
Do not include the "correct/total" results of dragndrop in logged answers

### DIFF
--- a/runestone/dragndrop/js/dragndrop.js
+++ b/runestone/dragndrop/js/dragndrop.js
@@ -348,6 +348,7 @@ DragNDrop.prototype.dragEval = function (logFlag) {
             "minHeight": this.minheight,
             "div_id": this.divid,
             "correct": this.correct,
+            "correctNum": this.correctNum,
             "dragNum": this.dragNum
         });
     }

--- a/runestone/dragndrop/js/dragndrop.js
+++ b/runestone/dragndrop/js/dragndrop.js
@@ -341,7 +341,6 @@ DragNDrop.prototype.dragEval = function (logFlag) {
     this.renderFeedback();
     if (logFlag) {  // Sometimes we don't want to log the answers--for example, on re-load of a timed exam
         let answer = this.pregnantIndexArray.join(";");
-        answer = answer + ":" + this.correctNum + "/" + this.dragNum ;
         this.logBookEvent({"event": "dragNdrop", "act": answer, "answer":answer, "minHeight": this.minheight, "div_id": this.divid, "correct": this.correct});
     }
 };

--- a/runestone/dragndrop/js/dragndrop.js
+++ b/runestone/dragndrop/js/dragndrop.js
@@ -341,7 +341,15 @@ DragNDrop.prototype.dragEval = function (logFlag) {
     this.renderFeedback();
     if (logFlag) {  // Sometimes we don't want to log the answers--for example, on re-load of a timed exam
         let answer = this.pregnantIndexArray.join(";");
-        this.logBookEvent({"event": "dragNdrop", "act": answer, "answer":answer, "minHeight": this.minheight, "div_id": this.divid, "correct": this.correct});
+        this.logBookEvent({
+            "event": "dragNdrop",
+            "act": answer,
+            "answer": answer,
+            "minHeight": this.minheight,
+            "div_id": this.divid,
+            "correct": this.correct,
+            "dragNum": this.dragNum
+        });
     }
 };
 


### PR DESCRIPTION
This line appears to be mistakenly added in https://github.com/RunestoneInteractive/RunestoneComponents/commit/0561b8372365e9b6e5d1c32b9f0fc407eed8ae96, which broke the dragndrop directive by causing an exception when loading saved answers and preventing dragndrop answers from being autograded.

Potential fix for https://github.com/RunestoneInteractive/RunestoneServer/issues/1025