### PR TITLE
Pr video https option

### DIFF
--- a/runestone/video/video.py
+++ b/runestone/video/video.py
@@ -171,7 +171,7 @@ class IframeVideo(Directive):
         'height': directives.nonnegative_int,
         'width': directives.nonnegative_int,
         'align': align,
-        'align': httpOption,
+        'http': httpOption,
     }
     default_width = 500
     default_height = 281

--- a/runestone/video/video.py
+++ b/runestone/video/video.py
@@ -185,7 +185,7 @@ class IframeVideo(Directive):
         if not self.options.get('align'):
             self.options['align'] = 'left'
         if not self.options.get('http'):
-            self.options['http'] = 'http'
+            self.options['http'] = 'https'
         raw_node = nodes.raw(self.block_text, self.html % self.options, format='html')
         raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [raw_node]

--- a/runestone/video/video.py
+++ b/runestone/video/video.py
@@ -137,8 +137,9 @@ class Video(RunestoneDirective):
     There are two directives added: ``youtube`` and ``vimeo``. The only
     argument is the video id of the video to include.
 
-    Both directives have three optional arguments: ``height``, ``width``
+    Both directives have four optional arguments: ``height``, ``width``
     and ``align``. Default height is 281 and default width is 500.
+    The default transport is HTTP although HTTPS can be specified.
 
     Example::
 
@@ -146,6 +147,7 @@ class Video(RunestoneDirective):
             :height: 315
             :width: 560
             :align: left
+            :http: http
 
     :copyright: (c) 2012 by Danilo Bargen.
     :license: BSD 3-clause
@@ -154,6 +156,10 @@ class Video(RunestoneDirective):
 def align(argument):
     """Conversion function for the "align" option."""
     return directives.choice(argument, ('left', 'center', 'right'))
+
+def httpOption(argument):
+    """Conversion function for the "http" option."""
+    return directives.choice(argument, ('http', 'https'))
 
 
 class IframeVideo(Directive):
@@ -165,6 +171,7 @@ class IframeVideo(Directive):
         'height': directives.nonnegative_int,
         'width': directives.nonnegative_int,
         'align': align,
+        'align': httpOption,
     }
     default_width = 500
     default_height = 281
@@ -177,6 +184,8 @@ class IframeVideo(Directive):
             self.options['height'] = self.default_height
         if not self.options.get('align'):
             self.options['align'] = 'left'
+        if not self.options.get('http'):
+            self.options['http'] = 'http'
         raw_node = nodes.raw(self.block_text, self.html % self.options, format='html')
         raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [raw_node]
@@ -188,8 +197,9 @@ class Youtube(IframeVideo):
    :height: 315
    :width: 560
    :align: left
+   :http: http
     """
-    html = '<iframe src="http://www.youtube.com/embed/%(video_id)s" \
+    html = '<iframe src="%(http)://www.youtube.com/embed/%(video_id)s" \
     width="%(width)u" height="%(height)u" frameborder="0" \
     webkitAllowFullScreen mozallowfullscreen allowfullscreen \
     class="align-%(align)s" seamless ></iframe>'
@@ -201,8 +211,9 @@ class Vimeo(IframeVideo):
    :height: 315
    :width: 560
    :align: left
+   :http: http
     """
-    html = '<iframe src="http://player.vimeo.com/video/%(video_id)s" \
+    html = '<iframe src="%(http)://player.vimeo.com/video/%(video_id)s" \
     width="%(width)u" height="%(height)u" frameborder="0" \
     webkitAllowFullScreen mozallowfullscreen allowFullScreen \
     class="align-%(align)s" seamless ></iframe>'

--- a/runestone/video/video.py
+++ b/runestone/video/video.py
@@ -199,7 +199,7 @@ class Youtube(IframeVideo):
    :align: left
    :http: http
     """
-    html = '<iframe src="%(http)://www.youtube.com/embed/%(video_id)s" \
+    html = '<iframe src="%(http)s://www.youtube.com/embed/%(video_id)s" \
     width="%(width)u" height="%(height)u" frameborder="0" \
     webkitAllowFullScreen mozallowfullscreen allowfullscreen \
     class="align-%(align)s" seamless ></iframe>'
@@ -213,7 +213,7 @@ class Vimeo(IframeVideo):
    :align: left
    :http: http
     """
-    html = '<iframe src="%(http)://player.vimeo.com/video/%(video_id)s" \
+    html = '<iframe src="%(http)s://player.vimeo.com/video/%(video_id)s" \
     width="%(width)u" height="%(height)u" frameborder="0" \
     webkitAllowFullScreen mozallowfullscreen allowFullScreen \
     class="align-%(align)s" seamless ></iframe>'


### PR DESCRIPTION
Added option to have video be either https or http with default to http. This is needed when viewing a runestone document through an iframe on a site using https -- without it, the enclosed videos will not show (at least one chrome). Both Youtube and Vimeo support https so making this the default shouldn't change behavior and is more compatible with "encrypt everywhere".