### PR TITLE
Fix: Score multiple choice, multiple-answer questions correctly.

### DIFF
--- a/runestone/assess/js/mchoice.js
+++ b/runestone/assess/js/mchoice.js
@@ -401,7 +401,10 @@ MultipleChoice.prototype.scoreMCMASubmission = function () {
             correctIndex++;
         }
     }
-    this.correct = (this.correctCount == this.correctList.length);
+    var numGiven = this.givenArray.length;
+    var numCorrect = this.correctCount;
+    var numNeeded = this.correctList.length;
+    this.correct = (numCorrect === numNeeded) && (numNeeded === numGiven);
 };
 
 
@@ -424,7 +427,7 @@ MultipleChoice.prototype.renderMCMAFeedBack = function () {
     var numNeeded = this.correctList.length;
     var feedbackText = this.feedbackString;
 
-    if (numCorrect === numNeeded && numNeeded === numGiven) {
+    if (this.correct) {
         $(this.feedBackDiv).html('Correct.<ol type="A">' + feedbackText + "</ul>");
         $(this.feedBackDiv).attr("class", "alert alert-success");
     } else {


### PR DESCRIPTION
If a students answers an MCMA question with all the correct answers and one or more incorrect answers, the existing code sets this.correct = true (so that the students get credit for getting the problem correct in the gradebook) and also shows that the problem is incorrect (so that the student thinks their answer is wrong, as it indeed is). If a student corrects their answer, it won't be saved (ajax.py doesn't overwrite correct answers) -- refreshing will again display the "incorrect" answer. (This change doesn't correct server-side bugs, just prevents it from happening in the future).