### PR TITLE
added fitb unit tests for casei option and numeric ranges

### DIFF
--- a/runestone/fitb/test/_sources/index.rst
+++ b/runestone/fitb/test/_sources/index.rst
@@ -65,3 +65,20 @@ Regex testing
        :2 1: Close.... (The second number is a tolerance, so this matches 1 or 3.)
        :x: Nope. (As earlier, this matches anything.)
 
+.. fillintheblank:: regexescapes1
+   :casei:
+
+   Windows system files are stored in: |blank|. 
+
+   -   :C\:\\Windows\\system: Correct.
+       :program files: Third party applications are stored here, not system files.
+       :x: Try again.
+
+.. fillintheblank:: regexescapes2
+   :casei:
+
+   Python lists are declared using: |blank|. 
+
+   -   :\[\]: Correct.
+       :x: Try again.
+

--- a/runestone/fitb/test/_sources/index.rst
+++ b/runestone/fitb/test/_sources/index.rst
@@ -1,3 +1,4 @@
+
 =====================
 This Is A New Project
 =====================
@@ -14,6 +15,19 @@ Fill in the Blank
         :x: Incorrect. Try 'red'.
     -   :away: Correct.
         :x: Incorrect. Try 'away'.
+
+Test 2.
+
+.. fillintheblank:: fill_2pi
+
+    What is the solution to the following:
+
+    :math:`2 * \pi =` |blank|.
+
+    - :6.28 0.005: Good job.
+      :3.27 3: Try higher.
+      :9.29 3: Try lower.
+      :.*: Incorrect. Try again.
 
 Error testing
 -------------
@@ -34,3 +48,18 @@ Error testing
     Not enough feedback. |blank| |blank|
 
     -   :Feedback: For blank 1.
+
+.. fillintheblank:: fillregex
+   :casei:
+
+   Complete the sentence: |blank| had a |blank| lamb. One plus one is: (note that if there aren't enough blanks for the feedback given, they're added to the end of the problem. So, we don't **need** to specify a blank here.)
+
+   -   :mary: Correct.
+       :Sue: Is wrong.
+       :wrong: Try again. (Note: the last item of feedback matches anything, regardless of the string it's given.)
+   -   :little: That's right.
+       :.*: Nope.
+   -   :0b10: Right on! Numbers can be given in decimal, hex (0x10 == 16), octal (0o10 == 8), binary (0b10 == 2), or using scientific notation (1e1 == 10), both here and by the user when answering the question.
+       :2 1: Close.... (The second number is a tolerance, so this matches 1 or 3.)
+       :x: Nope. (As earlier, this matches anything.)
+

--- a/runestone/fitb/test/_sources/index.rst
+++ b/runestone/fitb/test/_sources/index.rst
@@ -49,12 +49,14 @@ Error testing
 
     -   :Feedback: For blank 1.
 
+Regex testing
+-------------
 .. fillintheblank:: fillregex
    :casei:
 
    Complete the sentence: |blank| had a |blank| lamb. One plus one is: (note that if there aren't enough blanks for the feedback given, they're added to the end of the problem. So, we don't **need** to specify a blank here.)
 
-   -   :mary: Correct.
+   -   :mary|Mair[a|e|i]: Correct.
        :Sue: Is wrong.
        :wrong: Try again. (Note: the last item of feedback matches anything, regardless of the string it's given.)
    -   :little: That's right.

--- a/runestone/fitb/test/test_fitb.py
+++ b/runestone/fitb/test/test_fitb.py
@@ -119,7 +119,8 @@ class FITBtests(RunestoneTestCase):
 
     def test_fitbregex(self):
         self.find_fitb("fillregex")
-        self.find_blank(0).send_keys(" mARy ")
+        self.find_blank(0).send_keys(" maire ")
+        #self.find_blank(0).send_keys(" mARy ")
         self.find_blank(1).send_keys("LITTLE")
         self.find_blank(2).send_keys("2")
         self.click_checkme()

--- a/runestone/fitb/test/test_fitb.py
+++ b/runestone/fitb/test/test_fitb.py
@@ -7,9 +7,9 @@ class FITB_Error_Tests(TestCase):
     def test_1(self):
         # Check for the following directive-level errors.
         directive_level_errors =  (
-            # Produced my mchoice id error1_no_content,
-            (20, 'Content block expected for the "fillintheblank" directive; none found.'),
-            (32, 'Not enough feedback for the number of blanks supplied.'),
+            # Produced my fitb id error1_no_content,
+            (34, 'Content block expected for the "fillintheblank" directive; none found.'),
+            (46, 'Not enough feedback for the number of blanks supplied.'),
         )
         for error_line, error_string in directive_level_errors:
             # The rst_prolog in conf.py confuses line numbers. Adjust for it.
@@ -18,9 +18,9 @@ class FITB_Error_Tests(TestCase):
         # Check for the following error inside the directive.
         inside_directive_errors = (
             # error2,
-            (24, 'the last item in a fill-in-the-blank question must be a bulleted list.'),
+            (38, 'the last item in a fill-in-the-blank question must be a bulleted list.'),
             # error3,
-            (30, 'each list item in a fill-in-the-blank problems must contain only one item, a field list.'),
+            (44, 'each list item in a fill-in-the-blank problems must contain only one item, a field list.'),
         )
         for error_line, error_string in inside_directive_errors:
             # The rst_prolog in conf.py confuses line numbers. Adjust for it.
@@ -34,9 +34,9 @@ class FITBtests(RunestoneTestCase):
     ## Helpers
     ## =======
     # Load the web page, then return the DIV containing a FITB question.
-    def find_fitb(self):
+    def find_fitb(self, elem_id):
         self.driver.get(self.host + "/index.html")
-        self.fitb = self.driver.find_element_by_id("fill1412")
+        self.fitb = self.driver.find_element_by_id(elem_id)
         return self.fitb
 
     # Find one of the blanks, based on the given index.
@@ -48,8 +48,8 @@ class FITBtests(RunestoneTestCase):
         self.fitb.find_element_by_tag_name('button').click()
 
     # Find the question's feedback element.
-    def find_feedback(self):
-        return self.fitb.find_element_by_id("fill1412_feedback")
+    def find_feedback(self, elem_id):
+        return self.fitb.find_element_by_id(elem_id + "_feedback")
 
     ## Tests
     ## =====
@@ -58,32 +58,32 @@ class FITBtests(RunestoneTestCase):
         '''
         http://runestoneinteractive.org/build/html/directives.html#fill-in-the-blank for documentation
         '''
-        self.find_fitb()
+        self.find_fitb("fill1412")
         self.find_blank(0).send_keys("red")
         self.click_checkme()
-        feedback = self.find_feedback()
+        feedback = self.find_feedback("fill1412")
         self.assertIn('Correct', feedback.text)
 
     # No answers yet -- no answer provided feedback.
     def test_fitb2(self):
-        self.find_fitb()
+        self.find_fitb("fill1412")
         self.click_checkme()
-        feedback = self.find_feedback()
+        feedback = self.find_feedback("fill1412")
         self.assertIsNotNone(feedback.text)
         self.assertIn("No answer provided.", feedback.text)
 
 
     # Both correct answers
     def test_fitb3(self):
-        self.find_fitb()
+        self.find_fitb("fill1412")
         self.find_blank(0).send_keys("red")
         self.find_blank(1).send_keys("away")
         self.click_checkme()
-        feedback = self.find_feedback()
+        feedback = self.find_feedback("fill1412")
         self.assertIn("Correct", feedback.text)
 
     def test_fitb4(self):
-        self.find_fitb()
+        self.find_fitb("fill1412")
         blank0 = self.find_blank(0)
         # Type an incorrect answer.
         blank0.send_keys("red")
@@ -93,5 +93,36 @@ class FITBtests(RunestoneTestCase):
         blank0.send_keys("red")
         self.find_blank(1).send_keys("away")
         self.click_checkme()
-        feedback = self.find_feedback()
+        feedback = self.find_feedback("fill1412")
         self.assertIn("Correct", feedback.text)
+
+    def test_fitboneblank_too_low(self):
+        self.find_fitb("fill_2pi")
+        self.find_blank(0).send_keys(" 6")
+        self.click_checkme()
+        feedback = self.find_feedback("fill_2pi")
+        self.assertIn('Try higher.', feedback.text)
+
+    def test_fitboneblank_wildcard(self):
+        self.find_fitb("fill_2pi")
+        self.find_blank(0).send_keys("I give up")
+        self.click_checkme()
+        feedback = self.find_feedback("fill_2pi")
+        self.assertIn('Incorrect. Try again.', feedback.text)
+
+    def test_fitbfillrange(self):
+        self.find_fitb("fill_2pi")
+        self.find_blank(0).send_keys(" 6.28 ")
+        self.click_checkme()
+        feedback = self.find_feedback("fill_2pi")
+        self.assertIn('Good job.', feedback.text)
+
+    def test_fitbregex(self):
+        self.find_fitb("fillregex")
+        self.find_blank(0).send_keys(" mARy ")
+        self.find_blank(1).send_keys("LITTLE")
+        self.find_blank(2).send_keys("2")
+        self.click_checkme()
+        feedback = self.find_feedback("fillregex")
+        self.assertIn('Correct.', feedback.text)
+

--- a/runestone/fitb/test/test_fitb.py
+++ b/runestone/fitb/test/test_fitb.py
@@ -127,3 +127,17 @@ class FITBtests(RunestoneTestCase):
         feedback = self.find_feedback("fillregex")
         self.assertIn('Correct.', feedback.text)
 
+    def test_regexescapes1(self):
+        self.find_fitb("regexescapes1")
+        self.find_blank(0).send_keys("C:\windows\system")
+        self.click_checkme()
+        feedback = self.find_feedback("regexescapes1")
+        self.assertIn('Correct.', feedback.text)
+
+    def test_regexescapes2(self):
+        self.find_fitb("regexescapes2")
+        self.find_blank(0).send_keys("[]")
+        self.click_checkme()
+        feedback = self.find_feedback("regexescapes2")
+        self.assertIn('Correct.', feedback.text)
+


### PR DESCRIPTION
I wasn't sure I completely understood the regex handling in the answer fields, so no tests for that.

But does have some tests for the `:casei:` option, implied blanks, and numeric ranges.