### PR TITLE
Audio Tour Revamp

### DIFF
--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -1069,6 +1069,17 @@ AudioTour.prototype = new RunestoneBase();
 
 // function to display the audio tours
 function AudioTour (divid, code, bnum, audio_text) {
+    this.audio_tour = null;
+    this.audio_code = null;
+    this.windowcode = null;
+    this.first_audio = null;
+    this.prev_audio = null;
+    this.pause_audio = null;
+    this.next_audio = null;
+    this.last_audio = null;
+    this.status = null;
+    this.stop_button = null;
+    this.tourButtons = [];
     this.elem = null; // current audio element playing
     this.currIndex = null; // current index
     this.len = null; // current length of audio files for tour
@@ -1079,7 +1090,6 @@ function AudioTour (divid, code, bnum, audio_text) {
     this.afile = null; // file name for audio
     this.playing = false; // flag to say if playing or not
     this.tourName = "";
-
     // Replacing has been done here to make sure special characters in the code are displayed correctly
     code = code.replaceAll("*doubleq*", "\"");
     code = code.replaceAll("*singleq*", "'");
@@ -1087,7 +1097,6 @@ function AudioTour (divid, code, bnum, audio_text) {
     code = code.replaceAll("*close*", ")");
     code = code.replaceAll("*nline*", "<br/>");
     var codeArray = code.split("\n");
-
     var audio_hash = [];
     var bval = [];
     var atype = audio_text.replaceAll("*doubleq*", "\"");
@@ -1097,7 +1106,6 @@ function AudioTour (divid, code, bnum, audio_text) {
         var aword = audio_type[i].split(";");
         bval.push(aword[0]);
     }
-
     var first = "<pre><div id='" + divid + "_l1'>" + "1.   " + codeArray[0] + "</div>";
     var num_lines = codeArray.length;
     for (var i = 1; i < num_lines; i++) {
@@ -1116,103 +1124,138 @@ function AudioTour (divid, code, bnum, audio_text) {
     //laying out the HTML content
 
     var bcount = 0;
-    var html_string = "<div class='modal-lightsout'></div><div class='modal-profile'><h3>Take an audio tour!</h3><div class='modal-close-profile'></div><p id='windowcode'></p><p id='" + divid + "_audiocode'></p>";
-    html_string += "<p id='status'></p>";
-    html_string += "<input type='image' src='../_static/first.png' width='25' id='first_audio' name='first_audio' title='Play first audio in tour' alt='Play first audio in tour' onerror=\"this.onerror=null;this.src='_static/first.png'\" disabled/>" +
-                   "<input type='image' src='../_static/prev.png' width='25' id='prev_audio' name='prev_audio' title='Play previous audio in tour' alt='Play previous audio in tour' onerror=\"this.onerror=null;this.src='_static/prev.png'\" disabled/>" +
-                   "<input type='image' src='../_static/pause.png' width='25' id='pause_audio' name='pause_audio' title='Pause current audio' alt='Pause current audio' onerror=\"this.onerror=null;this.src='_static/pause.png'\" disabled/>" + "" +
-                   "<input type='image' src='../_static/next.png' width ='25' id='next_audio' name='next_audio' title='Play next audio in tour' alt='Play next audio in tour' onerror=\"this.onerror=null;this.src='_static/next.png'\" disabled/>" +
-                   "<input type='image' src='../_static/last.png' width ='25' id='last_audio' name='last_audio' title='Play last audio in tour' alt='Play last audio in tour' onerror=\"this.onerror=null;this.src='_static/last.png'\" disabled/><br/>";
+
     for (var i = 0; i < audio_type.length - 1; i++) {
-        html_string += "<input type='button' style='margin-right:5px;' class='btn btn-default btn-sm' id='button_audio_" + i + "' name='button_audio_" + i + "' value=" + bval[i] + " />";
+        var newButton = document.createElement("button");
+        newButton.className = "btn btn-success";
+        newButton.innerHTML = bval[i].replace(/\"/g,"");
+        this.tourButtons.push(newButton);
         bcount++;
     }
-    //html_string += "<p id='hightest'></p><p id='hightest1'></p><br/><br/><p id='test'></p><br/><p id='audi'></p></div>";
-    html_string += "</div>";
+    this.audio_tour = document.createElement("div");
+    this.audio_tour.align = "center";
 
-    var tourdiv = document.createElement('div');
-    document.body.appendChild(tourdiv);
-    $(tourdiv).html(html_string);
-    $('#windowcode').html(first);
+    this.audio_code = document.createElement("p");
 
-    // Position modal box
-    $.fn.center = function () {
-        this.css("position", "absolute");
-        // y position
-        this.css("top", ($(window).scrollTop() + $(navbar).height() + 10 + "px"));
-        // show window on the left so that you can see the output from the code still
-        this.css("left", ($(window).scrollLeft() + "px"));
-        return this;
-    };
+    this.windowcode = document.createElement("div");
+    this.windowcode.align = "left";
+    $(this.windowcode).html(first);
 
-    $(".modal-profile").center();
-    $('.modal-profile').fadeIn("slow");
-    //$('.modal-lightsout').css("height", $(document).height());
-    $('.modal-lightsout').fadeTo("slow", .5);
-    $('.modal-close-profile').show();
+    this.first_audio = document.createElement("button");
+    this.prev_audio = document.createElement("button");
+    this.pause_audio = document.createElement("button");
+    this.next_audio = document.createElement("button");
+    this.last_audio = document.createElement("button");
 
-    // closes modal box once close link is clicked, or if the lights out divis clicked
-    $('.modal-close-profile, .modal-lightsout').click( (function () {
+    this.first_audio.className = "btn-default glyphicon glyphicon-fast-backward";
+    this.prev_audio.className = "btn-default glyphicon glyphicon-step-backward";
+    this.pause_audio.className = "btn-default glyphicon glyphicon-pause";
+    this.next_audio.className = "btn-default glyphicon glyphicon-step-forward";
+    this.last_audio.className = "btn-default glyphicon glyphicon-fast-forward";
+
+    this.first_audio.setAttribute("style", "height: 22px; width: 25px; border-radius: 4px; margin-right:2px;");
+    this.prev_audio.setAttribute("style", "height: 22px; width: 25px; border-radius: 4px; margin-right:2px;");
+    this.pause_audio.setAttribute("style", "height: 22px; width: 25px; border-radius: 4px; margin-right:2px;");
+    this.next_audio.setAttribute("style", "height: 22px; width: 25px; border-radius: 4px; margin-right:2px;");
+    this.last_audio.setAttribute("style", "height: 22px; width: 25px; border-radius: 4px; margin-right:2px;");
+
+    this.first_audio.name = "first_audio";
+    this.prev_audio.name = "prev_audio";
+    this.pause_audio.name = "pause_audio";
+    this.next_audio.name = "next_audio";
+    this.last_audio.name = "last_audio";
+
+    this.first_audio.title = "Play first audio in tour";
+    this.prev_audio.title = "Play previous audio in tour";
+    this.pause_audio.title = "Pause current audio";
+    this.next_audio.title = "Play next audio in tour";
+    this.last_audio.title = "Play last audio in tour";
+
+    this.first_audio.setAttribute("aria-label", "Play first audio in tour");
+    this.prev_audio.setAttribute("aria-label", "Play previous audio in tour");
+    this.pause_audio.setAttribute("aria-label", "Pause audio");
+    this.next_audio.setAttribute("aria-label", "Play next audio in tour");
+    this.last_audio.setAttribute("aria-label", "Play last audio in tour");
+
+    this.first_audio.disabled = true;
+    this.prev_audio.disabled = true;
+    this.pause_audio.disabled = true;
+    this.next_audio.disabled = true;
+    this.last_audio.disabled = true;
+
+    this.status = document.createElement("div");
+    this.status.className = "alert alert-info";
+    this.status.setAttribute("style", "display: none;");
+
+    this.stop_button = document.createElement("button");
+    this.stop_button.className = "btn btn-default";
+    this.stop_button.innerHTML = "Stop tour";
+
+    $(this.audio_tour).append(this.audio_code, this.windowcode, document.createElement("br"), this.first_audio, this.prev_audio, this.pause_audio, this.next_audio, this.last_audio, document.createElement("br"), this.status, document.createElement("br"), this.tourButtons, this.stop_button);
+    $("#"+divid+" .ac_code_div").append(this.audio_tour);
+    $("#"+divid+" .ac_code_div").css("width", "50%");
+    $('#'+divid+' .CodeMirror.cm-s-default.ui-resizable').hide();
+    $('#'+divid+' .ac_opt.btn.btn-default:last-child').hide();
+
+    $(this.stop_button).click( (function () {
         if (this.playing) {
             this.elem.pause();
         }
         //log change to db
         this.logBookEvent({'event': 'Audio', 'act': 'closeWindow', 'div_id': divid});
-        $('.modal-profile').fadeOut("slow");
-        $('.modal-lightsout').fadeOut("slow");
-        document.body.removeChild(tourdiv);
+        $(this.audio_tour).remove();
+        $('#'+divid+' .CodeMirror.cm-s-default.ui-resizable').show();
+        $('#'+divid+' .ac_opt.btn.btn-default:last-child').show();
+        $("#"+divid+" .ac_code_div").css("width", "");
     }).bind(this));
 
-    // Accommodate buttons for a maximum of five tours
-
-    $('#' + 'button_audio_0').click((function () {
+    $(this.tourButtons[0]).click((function () {
         this.tour(divid, audio_hash[0], bcount);
     }).bind(this));
-    $('#' + 'button_audio_1').click((function () {
+    $(this.tourButtons[1]).click((function () {
         this.tour(divid, audio_hash[1], bcount);
     }).bind(this));
-    $('#' + 'button_audio_2').click((function () {
+    $(this.tourButtons[2]).click((function () {
         this.tour(divid, audio_hash[2], bcount);
     }).bind(this));
-    $('#' + 'button_audio_3').click((function () {
+    $(this.tourButtons[3]).click((function () {
         this.tour(divid, audio_hash[3], bcount);
     }).bind(this));
-    $('#' + 'button_audio_4').click((function () {
+    $(this.tourButtons[4]).click((function () {
         this.tour(divid, audio_hash[4], bcount);
     }).bind(this));
 
     // handle the click to go to the next audio
-    $('#first_audio').click((function () {
+    $(this.first_audio).click((function () {
         this.firstAudio();
     }).bind(this));
 
     // handle the click to go to the next audio
-    $('#prev_audio').click((function () {
+    $(this.prev_audio).click((function () {
         this.prevAudio();
     }).bind(this));
-
+    
     // handle the click to pause or play the audio
-    $('#pause_audio').click((function () {
-        this.pauseAndPlayAudio();
+    $(this.pause_audio).click((function () {
+        this.pauseAndPlayAudio(divid);
     }).bind(this));
 
     // handle the click to go to the next audio
-    $('#next_audio').click((function () {
+    $(this.next_audio).click((function () {
         this.nextAudio();
     }).bind(this));
 
     // handle the click to go to the next audio
-    $('#last_audio').click((function () {
+    $(this.last_audio).click((function () {
         this.lastAudio();
     }).bind(this));
 
     // make the image buttons look disabled
-    $("#first_audio").css('opacity', 0.25);
-    $("#prev_audio").css('opacity', 0.25);
-    $("#pause_audio").css('opacity', 0.25);
-    $("#next_audio").css('opacity', 0.25);
-    $("#last_audio").css('opacity', 0.25);
-
+    $(this.first_audio).css('opacity', 0.25);
+    $(this.prev_audio).css('opacity', 0.25);
+    $(this.pause_audio).css('opacity', 0.25);
+    $(this.next_audio).css('opacity', 0.25);
+    $(this.last_audio).css('opacity', 0.25);
 }
 
 AudioTour.prototype.tour = function (divid, audio_type, bcount) {
@@ -1220,26 +1263,29 @@ AudioTour.prototype.tour = function (divid, audio_type, bcount) {
     this.buttonCount = bcount;
     this.theDivid = divid;
 
+    this.status.setAttribute("style", "display: inline-block; margin-top: 7px; margin-bottom: 3px;");
+
     // enable prev, pause/play and next buttons and make visible
-    $('#first_audio').removeAttr('disabled');
-    $('#prev_audio').removeAttr('disabled');
-    $('#pause_audio').removeAttr('disabled');
-    $('#next_audio').removeAttr('disabled');
-    $('#last_audio').removeAttr('disabled');
-    $("#first_audio").css('opacity', 1.0);
-    $("#prev_audio").css('opacity', 1.0);
-    $("#pause_audio").css('opacity', 1.0);
-    $("#next_audio").css('opacity', 1.0);
-    $("#last_audio").css('opacity', 1.0);
+    $(this.first_audio).removeAttr('disabled');
+    $(this.prev_audio).removeAttr('disabled');
+    $(this.pause_audio).removeAttr('disabled');
+    $(this.next_audio).removeAttr('disabled');
+    $(this.last_audio).removeAttr('disabled');
+
+    $(this.first_audio).css('opacity', 1.0);
+    $(this.prev_audio).css('opacity', 1.0);
+    $(this.pause_audio).css('opacity', 1.0);
+    $(this.next_audio).css('opacity', 1.0);
+    $(this.last_audio).css('opacity', 1.0);
 
     // disable tour buttons
     for (var i = 0; i < bcount; i++)
-        $('#button_audio_' + i).attr('disabled', 'disabled');
+        $(this.tourButtons[i]).attr('disabled', 'disabled');
 
     var atype = audio_type.split(";");
     var name = atype[0].replaceAll("\"", " ");
     this.tourName = name;
-    $('#status').html("Starting the " + name);
+    $(this.status).html("Click the play button to begin the " + name);
 
     //log tour type to db
     this.logBookEvent({'event': 'Audio', 'act': name, 'div_id': divid});
@@ -1262,7 +1308,7 @@ AudioTour.prototype.tour = function (divid, audio_type, bcount) {
         // akey+".mp3' type='audio/mpeg'><source src='http://ice-web.cc.gatech.edu/ce21/audio/"+akey+
         // ".ogg' type='audio/ogg'>Your browser does not support the audio tag</audio>";
 
-        var dir = "http://media.interactivepython.org/" + eBookConfig.basecourse + "/audio/";
+        var dir = "http://media.interactivepython.org/" + eBookConfig.basecourse.toLowerCase() + "/audio/";
         //var dir = "../_static/audio/"
         str += "<audio id=" + akey + " preload='auto' >";
         str += "<source src='" + dir + akey + ".wav' type='audio/wav'>";
@@ -1273,31 +1319,19 @@ AudioTour.prototype.tour = function (divid, audio_type, bcount) {
         this.ahash[akey] = lnums;
         this.aname.push(akey);
     }
-    var ahtml = "#" + divid + "_audiocode";
-    $(ahtml).html(str); // set the html to the audio tags
+    $(this.audio_code).html(str);
     this.len = this.aname.length; // set the number of audio file in the tour
-
-    // start at the first audio
+    
     this.currIndex = 0;
-
-    // play the first audio in the tour
     this.playCurrIndexAudio();
 };
 
 AudioTour.prototype.handlePlaying = function() {
-
-    // if this.playing audio pause it
-    if (this.playing) {
-
-        this.elem.pause();
-
-        // unbind current ended
-        $('#' + this.afile).unbind('ended');
-
-        // unhighlight the prev lines
-        this.unhighlightLines(this.theDivid, this.ahash[this.aname[this.currIndex]]);
-    }
-
+    this.elem.pause();
+    // unbind current ended
+    $('#' + this.afile).unbind('ended');
+    // unhighlight the prev lines
+    this.unhighlightLines(this.theDivid, this.ahash[this.aname[this.currIndex]]);
 };
 
 AudioTour.prototype.firstAudio = function () {
@@ -1386,24 +1420,26 @@ AudioTour.prototype.playCurrIndexAudio = function () {
 
 // handle the end of the tour
 AudioTour.prototype.handleTourEnd = function () {
+    $(this.status).html("The " + this.tourName + " has ended.");
+    this.pause_audio.className = "btn-default glyphicon glyphicon-pause";
+    this.pause_audio.title = "Pause audio";
+    this.pause_audio.setAttribute("aria-label", "Pause audio");
 
-    $('#status').html(" The " + this.tourName + " Ended");
+    $(this.first_audio).attr('disabled', 'disabled');
+    $(this.prev_audio).attr('disabled', 'disabled');
+    $(this.pause_audio).attr('disabled', 'disabled');
+    $(this.next_audio).attr('disabled', 'disabled');
+    $(this.last_audio).attr('disabled', 'disabled');
 
-    // disable the prev, pause/play, and next buttons and make them more invisible
-    $('#first_audio').attr('disabled', 'disabled');
-    $('#prev_audio').attr('disabled', 'disabled');
-    $('#pause_audio').attr('disabled', 'disabled');
-    $('#next_audio').attr('disabled', 'disabled');
-    $('#last_audio').attr('disabled', 'disabled');
-    $("#first_audio").css('opacity', 0.25);
-    $("#prev_audio").css('opacity', 0.25);
-    $("#pause_audio").css('opacity', 0.25);
-    $("#next_audio").css('opacity', 0.25);
-    $("#last_audio").css('opacity', 0.25);
+    $(this.first_audio).css('opacity', 0.25);
+    $(this.prev_audio).css('opacity', 0.25);
+    $(this.pause_audio).css('opacity', 0.25);
+    $(this.next_audio).css('opacity', 0.25);
+    $(this.last_audio).css('opacity', 0.25);
 
     // enable the tour buttons
     for (var j = 0; j < this.buttonCount; j++)
-        $('#button_audio_' + j).removeAttr('disabled');
+        $(this.tourButtons[j]).removeAttr('disabled');
 };
 
 // only call this one after the first time
@@ -1438,17 +1474,22 @@ AudioTour.prototype.outerAudio = function () {
 AudioTour.prototype.playWhenReady = function (afile, divid, ahash) {
     // unbind current
     $('#' + afile).unbind('canplaythrough');
-    //console.log("in playWhenReady " + elem.duration);
-
-    $('#status').html("Playing the " + this.tourName);
     this.elem.currentTime = 0;
-    this.highlightLines(divid, ahash[afile]);
-    $('#' + afile).bind('ended', (function () {
-        this.outerAudio();
-    }).bind(this));
     this.playing = true;
-    this.elem.play();
-
+    //console.log("in playWhenReady " + elem.duration);
+    this.highlightLines(divid, ahash[afile]);
+    if (this.pause_audio.className === "btn-default glyphicon glyphicon-pause") {
+        $(this.status).html("Playing the " + this.tourName);
+        $('#' + afile).bind('ended', (function () {
+        this.outerAudio();
+        }).bind(this));
+        this.elem.play();
+    }
+    else {
+        $('#' + afile).bind('ended', (function () {
+        this.outerAudio();
+        }).bind(this));
+    }
 };
 
 
@@ -1461,7 +1502,7 @@ AudioTour.prototype.playaudio = function (i, aname, divid, ahash) {
     //console.log("in playaudio " + elem.duration);
     if (isNaN(this.elem.duration) || this.elem.duration == 0) {
         // set the status
-        $('#status').html("Loading audio.  Please wait.   If it doesn't start soon close this window (click on the red X) and try again");
+        $(this.status).html("Loading audio.  Please wait.   If the tour doesn't start soon click on 'Stop Tour' and try again.");
         $('#' + this.afile).bind('canplaythrough', (function () {
             this.playWhenReady(this.afile, divid, ahash);
         }).bind(this));
@@ -1473,16 +1514,18 @@ AudioTour.prototype.playaudio = function (i, aname, divid, ahash) {
 };
 
 // pause if this.playing and play if paused
-AudioTour.prototype.pauseAndPlayAudio = function () {
-    var btn = document.getElementById('pause_audio');
+AudioTour.prototype.pauseAndPlayAudio = function (divid) {
+    var btn = this.pause_audio;
 
     // if paused and clicked then continue from current
     if (this.elem.paused) {
         // calcualte the time left to play in milliseconds
         counter = (this.elem.duration - this.elem.currentTime) * 1000;
         this.elem.play(); // start the audio from current spot
-        document.getElementById("pause_audio").src = "../_static/pause.png";
-        document.getElementById("pause_audio").title = "Pause current audio";
+        this.pause_audio.className = "btn-default glyphicon glyphicon-pause";
+        this.pause_audio.title = "Pause current audio";
+        this.pause_audio.setAttribute("aria-label", "Pause audio");
+        $(this.status).html("Playing the " + this.tourName);
         //log change to db
         this.logBookEvent({'event': 'Audio', 'act': 'play', 'div_id': this.theDivid});
     }
@@ -1490,8 +1533,10 @@ AudioTour.prototype.pauseAndPlayAudio = function () {
     // if audio was this.playing pause it
     else if (this.playing) {
         this.elem.pause(); // pause the audio
-        document.getElementById("pause_audio").src = "../_static/play.png";
-        document.getElementById("pause_audio").title = "Play paused audio";
+        this.pause_audio.className = "btn-default glyphicon glyphicon-play";
+        this.pause_audio.title = "Play paused audio";
+        this.pause_audio.setAttribute("aria-label", "Play paused audio");
+        $(this.status).html("The " + this.tourName + " has been paused. Click on the play button to resume the tour.");
         //log change to db
         this.logBookEvent({'event': 'Audio', 'act': 'pause', 'div_id': this.theDivid});
     }


### PR DESCRIPTION
1. Changed the audio tour UI - instead of a separate screen popping up, the audio tour now launches in the same screen, right below the "Audio Tour" button.

2. Because the audio tour doesn't require a separate screen to pop up now, the user can have audio tours from multiple coding examples open simultaneously.

3. Earlier, images were being used as place-holders for media control buttons (that is, the "play button", "next-audio button" etc. were images); I have replaced them with actual HTML button tags.

4. A bunch of bug fixes, for example, earlier audio would play when the user clicked on the "next audio" button even though "pause audio" was selected.

5. Corrected the URL path for audio files.

6. **PR now includes code that only effects audio tours**

I have tested the new audio tour on Chrome, Safari and Firefox.