### PR TITLE
Avoid repeating same database error in activecode.py

### DIFF
--- a/runestone/activecode/activecode.py
+++ b/runestone/activecode/activecode.py
@@ -361,11 +361,13 @@ config values (conf.py):
                 available_files = self.options.get('available_files', "")
             ))
         else:
-            print("Unable to save to source_code table in activecode.py. Possible problems:")
-            print("  1. dburl or course_id are not set in conf.py for your book")
-            print("  2. unable to connect to the database using dburl")
-            print("")
-            print("This should only affect the grading interface. Everything else should be fine.")
+            if not hasattr(env, 'dberr_activecode_reported') or not env.dberr_activecode_reported:
+                env.dberr_activecode_reported = True
+                print("Unable to save to source_code table in activecode.py. Possible problems:")
+                print("  1. dburl or course_id are not set in conf.py for your book")
+                print("  2. unable to connect to the database using dburl")
+                print("")
+                print("This should only affect the grading interface. Everything else should be fine.")
 
 
         acnode = ActivcodeNode(self.options, rawsource=self.block_text)


### PR DESCRIPTION
Some authors use the `runestone` command just to preview their contributions and don't need to configure databases on their computers. In this scenario, the `activecode` directive emits the same error for each occurrence of the directive:
```
Unable to save to source_code table in activecode.py. Possible problems:
  1. dburl or course_id are not set in conf.py for your book
  2. unable to connect to the database using dburl

This should only affect the grading interface. Everything else should be fine.
```
With this small PR the `activecode` directive will report that error only on the first occurrence.