### PR TITLE
fix for codlens arrows and indent

### DIFF
--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -1944,6 +1944,7 @@ LiveCode.prototype.checkFile = function(file, resolve, reject) {
     xhr.onload = (function () {
         switch(xhr.status) {
             case 208:
+            case 404:
                 // console.log("File not on Server");
                 this.pushDataFile(file, resolve, reject);
                 break;

--- a/runestone/activecode/test/test_activecode.py
+++ b/runestone/activecode/test/test_activecode.py
@@ -56,7 +56,7 @@ class ActiveCodeTests(RunestoneTestCase):
         self.assertEqual(output.text.strip(), "Hello World")
 
 
-    def test_datafile(self):
+    def xxtest_datafile(self):
         '''
         Runs test2 example
         Code is dependent on supplementary file
@@ -71,8 +71,9 @@ class ActiveCodeTests(RunestoneTestCase):
 
         count = 0
         # Give it some time run
+        print(output.text)
         while output.text.strip() != "Width: 25.0" and count < 20:
             count += 1
             time.sleep(.5)
 
-        self.assertLess(count, 20)
+        self.assertLess(count, 20)  # This is not a good way to test this.

--- a/runestone/activecode/test/test_activecode.py
+++ b/runestone/activecode/test/test_activecode.py
@@ -56,7 +56,7 @@ class ActiveCodeTests(RunestoneTestCase):
         self.assertEqual(output.text.strip(), "Hello World")
 
 
-    def xxtest_datafile(self):
+    def test_datafile(self):
         '''
         Runs test2 example
         Code is dependent on supplementary file
@@ -76,4 +76,4 @@ class ActiveCodeTests(RunestoneTestCase):
             count += 1
             time.sleep(.5)
 
-        self.assertLess(count, 20)  # This is not a good way to test this.
+        self.assertLess(count, 20)

--- a/runestone/common/css/presenter_mode.css
+++ b/runestone/common/css/presenter_mode.css
@@ -32,7 +32,7 @@
 }
 
 div.ExecutionVisualizer #dataViz{
-  margin: 0;
+  margin: 0;  
 }
 
 div.ExecutionVisualizer div#stackHeader {
@@ -80,9 +80,11 @@ div.ExecutionVisualizer div#heap {
   margin: 0 auto;
 }
 
+/*  bnm -- comment this out for now as it breaks codelens indentation and arrows
 .visualizer tr{
   display: flex;
 }
+*/
 
 #vizLayoutTd{
   flex: 1;


### PR DESCRIPTION
This fixes the problems with indentation and the arrows for CodeLens. This raises questions about how and whether and to what extent we want to use flexbox layout going forward.