### PR TITLE
Cleanup directive numbering

### DIFF
--- a/runestone/assess/assessbase.py
+++ b/runestone/assess/assessbase.py
@@ -51,35 +51,10 @@ def escapejs(value):
 class Assessment(RunestoneIdDirective):
     """Base Class for assessments"""
 
-    def getNumber(self):
-        env = self.state.document.settings.env
-        if not hasattr(env,'assesscounter'):
-            env.assesscounter = 0
-        env.assesscounter += 1
-
-        res = "Q-%d"
-
-        if hasattr(env,'assessprefix'):
-            res = env.assessprefix + "%d"
-
-        res = res % env.assesscounter
-
-        if hasattr(env, 'assesssuffix'):
-            res += env.assesssuffix
-
-        return res
-
-
     def run(self):
         super(Assessment, self).run()
-        self.options['qnumber'] = self.getNumber()
 
         if self.content:
-            if self.content[0][:2] == '..':  # first line is a directive
-                self.content[0] = self.options['qnumber'] + ': \n\n' + self.content[0]
-            else:
-                self.content[0] = self.options['qnumber'] + ': ' + self.content[0]
-
             if 'iscode' in self.options:
                 self.options['bodytext'] = '<pre>' + "\n".join(self.content) + '</pre>'
             else:

--- a/runestone/assess/multiplechoice.py
+++ b/runestone/assess/multiplechoice.py
@@ -201,6 +201,13 @@ class MChoice(Assessment):
         mcNode.template_option = OPTION
         mcNode.template_end = TEMPLATE_END
 
+        # For MChoice its better to insert the qnum into the content before further processing.
+        if self.content:
+            if self.content[0][:2] == '..':  # first line is a directive
+                self.content[0] = self.options['qnumber'] + ': \n\n' + self.content[0]
+            else:
+                self.content[0] = self.options['qnumber'] + ': ' + self.content[0]
+
         self.state.nested_parse(self.content, self.content_offset, mcNode)
         env = self.state.document.settings.env
         self.options['divclass'] = env.config.mchoice_div_class

--- a/runestone/assess/multiplechoice.py
+++ b/runestone/assess/multiplechoice.py
@@ -202,11 +202,7 @@ class MChoice(Assessment):
         mcNode.template_end = TEMPLATE_END
 
         # For MChoice its better to insert the qnum into the content before further processing.
-        if self.content:
-            if self.content[0][:2] == '..':  # first line is a directive
-                self.content[0] = self.options['qnumber'] + ': \n\n' + self.content[0]
-            else:
-                self.content[0] = self.options['qnumber'] + ': ' + self.content[0]
+        self.updateContent()
 
         self.state.nested_parse(self.content, self.content_offset, mcNode)
         env = self.state.document.settings.env

--- a/runestone/clickableArea/clickable.py
+++ b/runestone/clickableArea/clickable.py
@@ -34,7 +34,7 @@ def setup(app):
 TEMPLATE = """
 <div class="runestone">
 <div data-component="clickablearea" class="%(divclass)s" id="%(divid)s" %(table)s %(correct)s %(incorrect)s>
-<span data-question>%(question)s</span>%(feedback)s%(clickcode)s
+<span data-question>%(qnumber)s: %(question)s</span>%(feedback)s%(clickcode)s
 """
 TEMPLATE_END = """
 </div>

--- a/runestone/common/runestonedirective.py
+++ b/runestone/common/runestonedirective.py
@@ -151,6 +151,13 @@ class RunestoneIdDirective(RunestoneDirective):
 
         return res
 
+    def updateContent(self):
+        if self.content:
+            if self.content[0][:2] == '..':  # first line is a directive
+                self.content[0] = self.options['qnumber'] + ': \n\n' + self.content[0]
+            else:
+                self.content[0] = self.options['qnumber'] + ': ' + self.content[0]
+
     def run(self):
         # Make sure the runestone directive at least requires an ID.
         assert self.required_arguments >= 1

--- a/runestone/common/runestonedirective.py
+++ b/runestone/common/runestonedirective.py
@@ -23,6 +23,8 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
 from docutils.utils import get_source_line
 
+UNNUMBERED_DIRECTIVES = ['activecode', 'reveal', 'video', 'youtube', 'vimeo', 'codelens', 'showeval', 'poll', 'tabbed', 'tab']
+
 # Provide a class which all Runestone nodes will inherit from.
 class RunestoneNode(nodes.Node):
     pass
@@ -126,6 +128,29 @@ class RunestoneDirective(Directive):
 
 # This is a base class for all Runestone directives which require a divid as their first parameter.
 class RunestoneIdDirective(RunestoneDirective):
+
+    def getNumber(self):
+        
+        if self.name in UNNUMBERED_DIRECTIVES:
+            return ""
+
+        env = self.state.document.settings.env
+        if not hasattr(env,'assesscounter'):
+            env.assesscounter = 0
+        env.assesscounter += 1
+
+        res = "Q-%d"
+
+        if hasattr(env,'assessprefix'):
+            res = env.assessprefix + "%d"
+
+        res = res % env.assesscounter
+
+        if hasattr(env, 'assesssuffix'):
+            res += env.assesssuffix
+
+        return res
+
     def run(self):
         # Make sure the runestone directive at least requires an ID.
         assert self.required_arguments >= 1
@@ -133,6 +158,8 @@ class RunestoneIdDirective(RunestoneDirective):
             id_ = self.options['divid'] = self.arguments[0]
         else:
             id_ = self.options['divid']
+
+        self.options['qnumber'] = self.getNumber()
 
         # Get references to `runestone data`_.
         env = self.state.document.settings.env

--- a/runestone/common/runestonedirective.py
+++ b/runestone/common/runestonedirective.py
@@ -23,7 +23,7 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
 from docutils.utils import get_source_line
 
-UNNUMBERED_DIRECTIVES = ['activecode', 'reveal', 'video', 'youtube', 'vimeo', 'codelens', 'showeval', 'poll', 'tabbed', 'tab']
+UNNUMBERED_DIRECTIVES = ['activecode', 'reveal', 'video', 'youtube', 'vimeo', 'codelens', 'showeval', 'poll', 'tabbed', 'tab', 'timed', 'disqus']
 
 # Provide a class which all Runestone nodes will inherit from.
 class RunestoneNode(nodes.Node):

--- a/runestone/dragndrop/dragndrop.py
+++ b/runestone/dragndrop/dragndrop.py
@@ -36,7 +36,7 @@ def setup(app):
 TEMPLATE_START = """
 <div class="%(divclass)s">
 <ul data-component="dragndrop" id="%(divid)s">
-    <span data-component="question">%(question)s</span>
+    <span data-component="question">%(qnumber)s: %(question)s</span>
 	%(feedback)s
 """
 

--- a/runestone/fitb/fitb.py
+++ b/runestone/fitb/fitb.py
@@ -147,11 +147,7 @@ class FillInTheBlank(RunestoneIdDirective):
         fitbNode.template_start = TEMPLATE_START
         fitbNode.template_end = TEMPLATE_END
 
-        if self.content:
-            if self.content[0][:2] == '..':  # first line is a directive
-                self.content[0] = self.options['qnumber'] + ': \n\n' + self.content[0]
-            else:
-                self.content[0] = self.options['qnumber'] + ': ' + self.content[0]
+        self.updateContent()
 
         self.state.nested_parse(self.content, self.content_offset, fitbNode)
         env = self.state.document.settings.env
@@ -269,6 +265,7 @@ class FillInTheBlank(RunestoneIdDirective):
             fitbNode.feedbackArray.append(blankArray)
 
         return [fitbNode]
+
 
 
 # BlankRole

--- a/runestone/fitb/fitb.py
+++ b/runestone/fitb/fitb.py
@@ -147,6 +147,11 @@ class FillInTheBlank(RunestoneIdDirective):
         fitbNode.template_start = TEMPLATE_START
         fitbNode.template_end = TEMPLATE_END
 
+        if self.content[0][:2] == '..':  # first line is a directive
+            self.content[0] = self.options['qnumber'] + ': \n\n' + self.content[0]
+        else:
+            self.content[0] = self.options['qnumber'] + ': ' + self.content[0]
+
         self.state.nested_parse(self.content, self.content_offset, fitbNode)
         env = self.state.document.settings.env
         self.options['divclass'] = env.config.fitb_div_class

--- a/runestone/fitb/fitb.py
+++ b/runestone/fitb/fitb.py
@@ -147,10 +147,11 @@ class FillInTheBlank(RunestoneIdDirective):
         fitbNode.template_start = TEMPLATE_START
         fitbNode.template_end = TEMPLATE_END
 
-        if self.content[0][:2] == '..':  # first line is a directive
-            self.content[0] = self.options['qnumber'] + ': \n\n' + self.content[0]
-        else:
-            self.content[0] = self.options['qnumber'] + ': ' + self.content[0]
+        if self.content:
+            if self.content[0][:2] == '..':  # first line is a directive
+                self.content[0] = self.options['qnumber'] + ': \n\n' + self.content[0]
+            else:
+                self.content[0] = self.options['qnumber'] + ': ' + self.content[0]
 
         self.state.nested_parse(self.content, self.content_offset, fitbNode)
         env = self.state.document.settings.env

--- a/runestone/parsons/parsons.py
+++ b/runestone/parsons/parsons.py
@@ -142,7 +142,6 @@ Example:
         addQuestionToDB(self)
 
         env = self.state.document.settings.env
-        self.options['qnumber'] = self.getNumber()
         self.options['instructions'] = ""
         self.options['code'] = self.content
         self.options['divclass'] = env.config.parsons_div_class

--- a/runestone/shortanswer/shortanswer.py
+++ b/runestone/shortanswer/shortanswer.py
@@ -32,7 +32,7 @@ def setup(app):
 
 TEXT = """
 <div class="runestone">
-<p data-component="shortanswer" class="%(divclass)s" id=%(divid)s %(optional)s>%(qnum)s: %(content)s</p>
+<p data-component="shortanswer" class="%(divclass)s" id=%(divid)s %(optional)s>%(qnumber)s: %(content)s</p>
 </div>
 """
 
@@ -83,7 +83,6 @@ config values (conf.py):
 
         self.options['optional'] = 'data-optional' if 'optional' in self.options else ''
         self.options['content'] = "<p>".join(self.content)
-        self.options['qnum'] = self.getNumber()
         journal_node = JournalNode(self.options, rawsource=self.block_text)
         journal_node.source, journal_node.line = self.state_machine.get_source_and_line(self.lineno)
 


### PR DESCRIPTION
Working on cleaning up directive numbering

Some directives should NOT be numbered

* reveal
* tabbed
* tab
* showeval
* timed_exam
* disqus
Some directives MIGHT want to be numbered
* codelens ??
* activecode??
* video
* youtube
* vimeo
* poll

And some DEFINITELY should be numbered

- [x] mchoice
- [x] fitb
- [x] clickable
- [x] dragndrop
- [x] parsons
- [x] shortanswer

Right now all on the definitely list are getting numbered and we are not increasing the count for the others.


