### PR TITLE
Allow multiple youtube videos on one page

### DIFF
--- a/runestone/video/video.py
+++ b/runestone/video/video.py
@@ -198,11 +198,7 @@ class IframeVideo(RunestoneIdDirective):
         raw_node.source, raw_node.line = self.state_machine.get_source_and_line(self.lineno)
         return [raw_node]
 
-# TODO - I'm pretty sure this breaks for the case of multiple youtubes on one page.
-# we should push players to an array.
-# There should probably be only one function called onYouTubeIframeAPIReady
-# this function should iterate over all the various videos creating players
-#
+
 class Youtube(IframeVideo):
     """
 .. youtube:: YouTubeID
@@ -214,36 +210,17 @@ class Youtube(IframeVideo):
    """
     html = '''
     <div class="runestone" style="margin-left: auto; margin-right:auto">
-    <div id="%(divid)s_vid"></div>
+	<iframe id="%(divid)s_vid" type="text/html" width="%(width)u" height="%(height)u"
+  src="https://www.youtube.com/embed/%(video_id)s?autoplay=0"
+  frameborder="0"></iframe>
     </div>
-    <script id="%(divid)s_script">
-      // 2. This code loads the IFrame Player API code asynchronously.
-      var tag = document.createElement('script');
-
-      tag.src = "https://www.youtube.com/iframe_api";
-      var ytScriptTag = document.getElementById('%(divid)s_script');
-      ytScriptTag.parentNode.insertBefore(tag, ytScriptTag);
-
-      // 3. This function creates an <iframe> (and YouTube player)
-      //    after the API code downloads.
-      var player;
-      function onYouTubeIframeAPIReady() {
-        player = new YT.Player('%(divid)s_vid', {
-          height: '%(height)u',
-          width: '%(width)u',
-          videoId: '%(video_id)s',
-          events: {
-            'onStateChange': onPlayerStateChange
-          }
-        });
-      }
-    </script>
     '''
 
     def run(self):
         raw_node = super(Youtube, self).run()
         addQuestionToDB(self)
         return raw_node
+
 
 class Vimeo(IframeVideo):
     """


### PR DESCRIPTION
Modified the class Youtube to directly build each video as an iframe rather than using the IFrame Player API. (https://developers.google.com/youtube/player_parameters). The existing IFramePlayer implementation only rendered the last video on any page.