### PR TITLE
bug fix for includes to make sure they end with newline

### DIFF
--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -1001,11 +1001,11 @@ ActiveCode.prototype.buildProg = function(useSuffix) {
         pretext = "";
         for (var x=0; x < this.includes.length; x++) {
             let iCode = this.getIncludedCode(this.includes[x]);
-            pretext = pretext + iCode;
+            pretext = pretext + iCode + "\n";
         }
         this.pretext = pretext;
         if(this.pretext) {
-            this.pretextLines = (this.pretext.match(/\n/g) || '').length + 1
+            this.pretextLines = (this.pretext.match(/\n/g) || '').length
         }
         prog = pretext + prog
     }


### PR DESCRIPTION
If included code didn't end in a newline (normally seems to be stripped), it was concatenating the last line of the included code with the first line of the user's code.