### PR TITLE
DRY: Get the local storage key from a single function

### DIFF
--- a/runestone/fitb/js/fitb.js
+++ b/runestone/fitb/js/fitb.js
@@ -179,7 +179,7 @@ FITB.prototype.checkLocalStorage = function () {
 };
 
 FITB.prototype.setLocalStorage = function (data) {
-    let key = eBookConfig.email + ":" + this.divid + "-given";
+    let key = this.localStorageKey();
     localStorage.setItem(key, JSON.stringify(data));
 };
 


### PR DESCRIPTION
I somehow missed on DRY that should have gone in 4899df3c48141018ceb34bb6c7b060453b381ca9.