### PR TITLE
Fix: Prevent answers from "leaking" from one course to another

### DIFF
--- a/runestone/common/js/runestonebase.js
+++ b/runestone/common/js/runestonebase.js
@@ -132,5 +132,5 @@ RunestoneBase.prototype.shouldUseServer = function (data) {
 
 // Return the key which to be used when accessing local storage.
 RunestoneBase.prototype.localStorageKey = function () {
-    return eBookConfig.email + ":" + this.divid + "-given";
+    return eBookConfig.email + ":" + eBookConfig.course + ":" + this.divid + "-given";
 }


### PR DESCRIPTION
This PR includes the course name in the key used for local storage. Without this, a student who took a course last semester from a course named fopp_fall_2018 will already have answers provided if they re-take in this semester in fopp_spring_2019.

**However**, I assume this will break existing local storage. How big an issue is this? I could include code to check for the old label, but only if necessary.