### PR TITLE
bigger Parsons block numbered font-size

### DIFF
--- a/runestone/parsons/css/parsons.css
+++ b/runestone/parsons/css/parsons.css
@@ -178,6 +178,11 @@
     background-color: transparent;
 }
 
+.parsons-text code {
+	float: none;
+}
+
+
 .parsons .block p {
 	margin: 0;
 }
@@ -264,8 +269,8 @@
 
 .block-label {
 	font-family: "Courier";
-	font-size: 10px;
-	color: #b0b0b0;
+	font-size: 90%;
+	color: #7e7ee7;
 	vertical-align: top;
 	white-space: pre;
 }

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -1438,7 +1438,7 @@ Parsons.prototype.initializeAreas = function(sourceBlocks, answerBlocks, options
 				addition = 2.1;
 			areaHeight += (item.outerHeight(true)+height_add*addition);
 			areaWidth = Math.max(areaWidth, item.outerWidth(true));
-			console.log(item.outerHeight(true));
+			
 		};
 	}
 	for (i = 0; i < blocks.length; i++) {

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -1416,17 +1416,29 @@ Parsons.prototype.initializeAreas = function(sourceBlocks, answerBlocks, options
 	// Establish the width and height of the droppable areas
 	var item, maxFunction;
 	areaHeight = 6;
+	var height_add = 0;
+	if(this.options.numbered != undefined) {
+		height_add = 1;
+	}
 	if (this.options.language == "natural") {
 		areaWidth = 300;
 		maxFunction = function(item) {
 			item.width(areaWidth - 22);
-			areaHeight += item.outerHeight(true);
+			var addition = 3.8;
+			if (item.outerHeight(true) != 38)
+				addition = 2.1*(item.outerHeight(true)-38)/21;
+			areaHeight += (item.outerHeight(true)+height_add*addition);
+
 		};
 	} else {
 		areaWidth = 0;
 		maxFunction = function(item) {
-			areaHeight += item.outerHeight(true);
+			var addition = 3.8;
+			if (item.outerHeight(true) != 38)
+				addition = 2.1;
+			areaHeight += (item.outerHeight(true)+height_add*addition);
 			areaWidth = Math.max(areaWidth, item.outerWidth(true));
+			console.log(item.outerHeight(true));
 		};
 	}
 	for (i = 0; i < blocks.length; i++) {
@@ -1435,6 +1447,7 @@ Parsons.prototype.initializeAreas = function(sourceBlocks, answerBlocks, options
 	this.areaWidth = areaWidth;
 	if(this.options.numbered != undefined) {
 		this.areaWidth += 25;
+		//areaHeight += (blocks.length);
 	}
 	this.areaHeight = areaHeight;
 	$(this.sourceArea).css({


### PR DESCRIPTION
The css file has been modified to give the numbers on the parsons block a larger font-size. It also fixes the problem with code always floating to the left as it was before in APCSAReview 17.1.1. Parsons.js contains parsons block height changes that must go along with the change in numbered font-size in css.