### PR TITLE
Reduce coding window to 80-character width.

### DIFF
--- a/runestone/activecode/css/activecode.css
+++ b/runestone/activecode/css/activecode.css
@@ -52,6 +52,7 @@
 .ac_section{
 	position: relative;
 	clear:both;
+	max-width: 800px !important;
 }
 .ac_section>* {
 	max-width: 500pt;


### PR DESCRIPTION
Keeping the coding window a bit smaller lines the text in the coding window up with the text on the page.