### PR TITLE
Misc fixes

### DIFF
--- a/runestone/assess/js/mchoice.js
+++ b/runestone/assess/js/mchoice.js
@@ -181,24 +181,20 @@ MultipleChoice.prototype.renderMCFormOpts = function () {
         var k = this.indexArray[j];
         var optid = this.divid + "_opt_" + k;
 
-        // Create the input
-        var input = document.createElement("input");
-        input.type = input_type;
-        input.name = "group1";
-        input.value = String(k);
-        input.id = optid;
-
         // Create the label for the input
         var label = document.createElement("label");
-        var labelspan = document.createElement("span");
-        label.appendChild(input);
-        label.appendChild(labelspan);
-        //$(label).attr("for", optid);
-        $(labelspan).html(String.fromCharCode(65 + j) + '. ' + this.answerList[k].content);
+        // If the content begins with a ``<p>``, put the label inside of it. (Sphinx 2.0 puts all content in a ``<p>``, while Sphinx 1.8 doesn't).
+        var content = this.answerList[k].content;
+        var prefix = '';
+        if (content.startsWith('<p>')) {
+            prefix = '<p>';
+            content = content.slice(3);
+        }
+        $(label).html(`${prefix}<input type="${input_type}" name="group1" value=${k} id=${optid}>${String.fromCharCode('A'.charCodeAt(0) + j)}. ${content}`);
 
         // create the object to store in optionArray
         var optObj = {
-            input: input,
+            input: document.getElementById(optid),
             label: label
         };
         this.optionArray.push(optObj);

--- a/runestone/fitb/fitb.py
+++ b/runestone/fitb/fitb.py
@@ -252,12 +252,12 @@ class FillInTheBlank(RunestoneIdDirective):
                 except (SyntaxError, ValueError, AssertionError):
                     # We can't parse this as a number, so assume it's a regex.
                     regex = (
-                        # The given regex must match the entire string, from the beginning (which may be preceeded by spaces) ...
-                        '^ *' +
-                        # ... to the contents (where a single space in the provided pattern is treated as one or more spaces in the student's anwer) ...
-                        feedback_field_name.rawsource.replace(' ', ' +')
+                        # The given regex must match the entire string, from the beginning (which may be preceeded by whitespaces) ...
+                        '^\s*' +
+                        # ... to the contents (where a single space in the provided pattern is treated as one or more whitespaces in the student's anwer) ...
+                        feedback_field_name.rawsource.replace(' ', '\s+')
                         # ... to the end (also with optional spaces).
-                        + ' *$'
+                        + '\s*$'
                     )
                     blankFeedbackDict = {
                         'regex': regex,

--- a/runestone/parsons/test/test_parsons.py
+++ b/runestone/parsons/test/test_parsons.py
@@ -29,16 +29,16 @@ class ParsonsTests(RunestoneTestCase):
         self.assertIsNotNone(source)
         blocks = source.find_elements_by_class_name("block")
         self.assertIsNotNone(source)
-        self.assertEquals(len(blocks), 5)
+        self.assertEqual(len(blocks), 5)
 
         # check that messages appear correctly
         checkme = self.driver.find_element_by_id('parsons-1-check')
         reset = self.driver.find_element_by_id('parsons-1-reset')
         message = self.driver.find_element_by_id("parsons-1-message")
         self.assertIsNotNone(message, None)
-        self.assertEquals(message.get_attribute("style"), "display: none;")
+        self.assertEqual(message.get_attribute("style"), "display: none;")
         checkme.click()
-        self.assertEquals(message.get_attribute("class"),"alert alert-danger")
+        self.assertEqual(message.get_attribute("class"),"alert alert-danger")
         reset.click()
         ActionChains(self.driver).drag_and_drop(source.find_element_by_id("parsons-1-block-3"), answer).perform()
         ActionChains(self.driver).drag_and_drop(source.find_element_by_id("parsons-1-block-2"), answer.find_element_by_id("parsons-1-block-3")).perform()
@@ -48,12 +48,12 @@ class ParsonsTests(RunestoneTestCase):
         self.wait_for_animation("#parsons-1-block-0")
         checkme.click()
         message = self.driver.find_element_by_id("parsons-1-message")
-        self.assertEquals(message.get_attribute("class"), "alert alert-info")
+        self.assertEqual(message.get_attribute("class"), "alert alert-info")
 
         # check that reset works
         reset.click()
         blocks = source.find_elements_by_class_name("block")
-        self.assertEquals(len(blocks), 5)
+        self.assertEqual(len(blocks), 5)
 
     def test_help(self):
         self.driver.get(self.host + "/index.html")
@@ -96,7 +96,7 @@ class ParsonsTests(RunestoneTestCase):
         self.assertTrue(self.wait_and_close_alert())
         self.wait_for_animation("#parsons-1-block-4")
         b4 = source.find_element_by_id("parsons-1-block-4")
-        self.assertEquals(b4.get_attribute("class"), "block disabled");
+        self.assertEqual(b4.get_attribute("class"), "block disabled");
         helpBtn.click() # provide Indentation
         self.assertTrue(self.wait_and_close_alert())
         self.wait_for_animation("#parsons-1-block-4")
@@ -106,7 +106,7 @@ class ParsonsTests(RunestoneTestCase):
         l6 = source.find_element_by_id("parsons-1-line-6")
         # There seems to be a timing issue -- a bit of delay makes this pass.
         time.sleep(0.1)
-        self.assertEquals(l6.get_attribute("class"), "prettyprint lang-py indent1")
+        self.assertEqual(l6.get_attribute("class"), "prettyprint lang-py indent1")
         self.assertFalse(self.f_exists("parsons-1-block-1"))
         b0 = answer.find_element_by_id("parsons-1-block-0")
         l1 = b0.find_element_by_id("parsons-1-line-1")
@@ -122,33 +122,33 @@ class ParsonsTests(RunestoneTestCase):
         helpBtn.click()
         self.assertTrue(self.wait_and_close_alert())
         answer_after = answer.get_attribute('innerHTML')
-        self.assertEquals(answer_initial, answer_after)
+        self.assertEqual(answer_initial, answer_after)
         source_after = source.get_attribute('innerHTML')
-        self.assertEquals(source_initial, source_after)
+        self.assertEqual(source_initial, source_after)
 
     def test_numbering(self):
         self.driver.get(self.host + "/index.html")
 
         # right label block
         rlb = self.driver.find_element_by_id('parsons-2-block-1')
-        self.assertEquals(len(rlb.find_elements_by_class_name("labels")), 1) # has label
-        self.assertEquals(len(rlb.find_elements_by_class_name("lines")), 1) # has lines
+        self.assertEqual(len(rlb.find_elements_by_class_name("labels")), 1) # has label
+        self.assertEqual(len(rlb.find_elements_by_class_name("lines")), 1) # has lines
         children = rlb.find_elements_by_xpath("*")
         self.assertTrue("lines" in children[0].get_attribute("class").split())
         self.assertTrue("labels" in children[1].get_attribute("class").split()) # label on right
 
         # left label block
         llb = self.driver.find_element_by_id('parsons-3-block-1')
-        self.assertEquals(len(llb.find_elements_by_class_name("labels")), 1) # has label
-        self.assertEquals(len(llb.find_elements_by_class_name("lines")), 1) # has lines
+        self.assertEqual(len(llb.find_elements_by_class_name("labels")), 1) # has label
+        self.assertEqual(len(llb.find_elements_by_class_name("lines")), 1) # has lines
         children = llb.find_elements_by_xpath("*")
         self.assertTrue("lines" in children[1].get_attribute("class").split())
         self.assertTrue("labels" in children[0].get_attribute("class").split()) # label on left
 
         # no label block
         nlb = self.driver.find_element_by_id('parsons-4-block-1')
-        self.assertEquals(len(nlb.find_elements_by_class_name("labels")), 0) # no label
-        self.assertEquals(len(nlb.find_elements_by_class_name("lines")), 1) # has lines
+        self.assertEqual(len(nlb.find_elements_by_class_name("labels")), 0) # no label
+        self.assertEqual(len(nlb.find_elements_by_class_name("lines")), 1) # has lines
 
     def wait_for_animation(self, selector):
         is_animation_in_progress = self.is_element_animated(selector)

--- a/runestone/shortanswer/js/shortanswer.js
+++ b/runestone/shortanswer/js/shortanswer.js
@@ -134,7 +134,7 @@ ShortAnswer.prototype.submitJournal = function () {
 
 
     this.setLocalStorage({answer: value, timestamp: new Date()})
-    this.logBookEvent({'event': 'shortanswer', 'act': JSON.stringify(value), 'div_id': this.divid});
+    this.logBookEvent({'event': 'shortanswer', 'act': value, 'div_id': this.divid});
     this.feedbackDiv.innerHTML = "Your answer has been saved.";
     $(this.feedbackDiv).removeClass("alert-danger");
     $(this.feedbackDiv).addClass("alert alert-success");

--- a/runestone/unittest_base.py
+++ b/runestone/unittest_base.py
@@ -4,7 +4,6 @@ import sys
 import platform
 import subprocess
 from selenium import webdriver
-from selenium.webdriver.remote import webelement
 from pyvirtualdisplay import Display
 
 # Select an unused port for serving web pages to the test suite.
@@ -41,7 +40,7 @@ class ModuleFixture(unittest.TestCase):
         if self.exit_status_success:
             self.assertFalse(p.returncode)
         # Run the server. Simply calling ``runestone serve`` fails, since the process killed isn't the actual server, but probably a setuptools-created launcher.
-        self.runestone_server = subprocess.Popen(['python', '-m', 'runestone', 'serve', '--port', PORT])
+        self.runestone_server = subprocess.Popen([sys.executable, '-m', 'runestone', 'serve', '--port', PORT])
 
         # Testing time in dominated by browser startup/shutdown. So, simply run all tests in a module in a single browser instance to speed things up. See ``RunestoneTestCase.setUp`` for additional code to (mostly) clear the browser between tests.
         #


### PR DESCRIPTION
- A student was cut-and-pasting from a Word document, and had answers marked wrong in a fitb question. The updated fitb allows tabs (what the student pasted in) and other whitespace.
- The shortanswer question's encoding is fixed.
- mchoice formatting is now correct on Sphinx 2.0 (and still works on 1.8.x).