### PR TITLE
server side reveal

### DIFF
--- a/runestone/reveal/test/_sources/index.rst
+++ b/runestone/reveal/test/_sources/index.rst
@@ -23,3 +23,10 @@ Reveal
     :hidetitle: Hide Content
 
     This content starts out hidden.
+
+.. reveal:: question2
+    :showtitle: Reveal Content
+    :hidetitle: Hide Content
+    :instructoronly:
+
+    This content starts out hidden.

--- a/runestone/reveal/test/pavement.py
+++ b/runestone/reveal/test/pavement.py
@@ -32,7 +32,8 @@ options(
                        'use_services': 'false',
                        'python3': 'false',
                        'dburl': '',
-                       'basecourse': 'reveal-test'
+                       'basecourse': 'reveal-test',
+                       'dynamic_pages': True
                         }
     )
 )

--- a/runestone/reveal/test/test_reveal.py
+++ b/runestone/reveal/test/test_reveal.py
@@ -47,3 +47,8 @@ class RevealQuestion_Tests(RunestoneTestCase):
 
         cnamestr = q1.get_attribute("style")
         self.assertEqual("display: none;", cnamestr)
+
+    def test_r4(self):
+        '''Check for is_instructor test '''
+        t1 = self.driver.find_element_by_id("reveal")
+        self.assertIn("{{ if is_instructor: }}", t1.get_attribute('innerHTML'))


### PR DESCRIPTION
This implements a feature whereby the contents of an instructoronly reveal are only sent to the browser if the current user is an instructor.