### PR TITLE
Fix: Fully specify import of componentdb.

### DIFF
--- a/runestone/activecode/test/pavement.py
+++ b/runestone/activecode/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 
 sys.path.append(os.getcwd())

--- a/runestone/assess/test/pavement.py
+++ b/runestone/assess/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/clickableArea/test/pavement.py
+++ b/runestone/clickableArea/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/common/project_template/pavement.tmpl
+++ b/runestone/common/project_template/pavement.tmpl
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 from socket import gethostname

--- a/runestone/common/test/test_error/pavement.py
+++ b/runestone/common/test/test_error/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/common/test/test_working/pavement.py
+++ b/runestone/common/test/test_working/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/dragndrop/test/pavement.py
+++ b/runestone/dragndrop/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/fitb/test/pavement.py
+++ b/runestone/fitb/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 from socket import gethostname

--- a/runestone/lp/test/pavement.py
+++ b/runestone/lp/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/matrixeq/test/pavement.py
+++ b/runestone/matrixeq/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/parsons/test/pavement.py
+++ b/runestone/parsons/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/poll/test/pavement.py
+++ b/runestone/poll/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 
 sys.path.append(os.getcwd())

--- a/runestone/question/test/pavement.py
+++ b/runestone/question/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 
 sys.path.append(os.getcwd())

--- a/runestone/reveal/test/pavement.py
+++ b/runestone/reveal/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/shortanswer/test/pavement.py
+++ b/runestone/shortanswer/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/showeval/test/pavement.py
+++ b/runestone/showeval/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/spreadsheet/test/pavement.py
+++ b/runestone/spreadsheet/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 from socket import gethostname

--- a/runestone/tabbedStuff/test/pavement.py
+++ b/runestone/tabbedStuff/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 

--- a/runestone/webgldemo/test/pavement.py
+++ b/runestone/webgldemo/test/pavement.py
@@ -3,7 +3,7 @@ from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
 import os, sys
-from runestone.server import get_dburl
+from runestone.server.componentdb import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
 


### PR DESCRIPTION
In general, starred imports are a bad thing. Here's one small step toward removing them -- fully specify an import for `get_dburl` instead of allowing a starred import to do the job. Ideally, the same update would be applied to all the `pavement.py` files out there as well.