### PR TITLE
get runlog as json, by visiting /runlog.json

### DIFF
--- a/runestone/common/js/runestonebase.js
+++ b/runestone/common/js/runestonebase.js
@@ -49,9 +49,9 @@ RunestoneBase.prototype.logRunEvent = function (eventInfo) {
         eventInfo.save_code = "True"
     }
     if (eBookConfig.useRunestoneServices && eBookConfig.logLevel > 0) {
-        jQuery.post(eBookConfig.ajaxURL + 'runlog', eventInfo) // Log the run event
+        jQuery.post(eBookConfig.ajaxURL + 'runlog.json', eventInfo) // Log the run event
             .done((function(data, status, whatever) {
-                data = JSON.parse(data);
+                // data = JSON.parse(data);
                 if (data.message) {
                     alert(data.message);
                 }


### PR DESCRIPTION
This resolves one instance of the latent bug where content-type header was coming in uncapitalized and different servers interpreted it as json or not. Explicitly ask for .json URL. Then don't parse it because jquery does that for us.