### PR TITLE
use relative_url (empty string) for ebookConfig.host

### DIFF
--- a/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -238,8 +238,7 @@
   {% if dynamic_pages == 'True' %}
     {% raw %}
     eBookConfig.useRunestoneServices = true;
-    eBookConfig.host = '{{= "{}://{}".format(request.env.wsgi_url_scheme,
-                                             request.env.http_host) }}';
+    eBookConfig.host = '';
     eBookConfig.app = eBookConfig.host + '/' + '{{= request.application }}';
     eBookConfig.course = '{{= course_name }}';
     eBookConfig.basecourse = '{{= base_course }}';


### PR DESCRIPTION
request.env.wsgi_url_scheme may get set to http instead of https when we ran this in our automated deployment.

Using relative urls seems to work fine here; if you ever want ajaxURL to be to a different server, that could still be added. There's currently no value from trying to getting the host from an environment variable since the same variable is used to determine the host for the current page, so let's just simplify an use relative urls.