### PR TITLE
Clean: Re-order imports by category.

### DIFF
--- a/runestone/common/project_template/pavement.tmpl
+++ b/runestone/common/project_template/pavement.tmpl
@@ -1,14 +1,16 @@
-import paver
-from paver.easy import *
-import paver.setuputils
-paver.setuputils.install_distutils_tasks()
-import os, sys
-from runestone.server import get_dburl
-from sphinxcontrib import paverutils
+import os
+import sys
 import pkg_resources
 from socket import gethostname
-from runestone import get_master_url
 
+from paver.easy import options, Bunch
+import paver.setuputils
+
+from runestone import get_master_url
+from runestone import build  # NOQA: F401 -- build is called implicitly by the paver driver.
+from runestone.server import get_dburl
+
+paver.setuputils.install_distutils_tasks()
 sys.path.append(os.getcwd())
 
 # The project name, for use below.
@@ -24,33 +26,34 @@ serving_dir = "%(build_dir)s/" + project_name
 dest = "%(dest)s"
 
 options(
-    sphinx = Bunch(docroot=".",),
+    sphinx=Bunch(docroot=".",),
 
-    build = Bunch(
+    build=Bunch(
         builddir=serving_dir,
         sourcedir="_sources",
         outdir=serving_dir,
         confdir=".",
-        template_args={'login_required':'%(login_req)s',
-                       'loglevel': %(log_level)d,
-                       'course_title': project_name,
-                       'python3': '%(python3)s',
-                       'dburl': '%(dburl)s',
-                       'default_ac_lang': '%(default_ac_lang)s',
-                       'jobe_server': 'http://jobe2.cosc.canterbury.ac.nz',
-                       'proxy_uri_runs': '/jobe/index.php/restapi/runs/',
-                       'proxy_uri_files': '/jobe/index.php/restapi/files/',
-                       'downloads_enabled': '%(downloads_enabled)s',
-                       'enable_chatcodes': '%(enable_chatcodes)s',
-                       'allow_pairs': '%(allow_pairs)s',
-                       'dynamic_pages': %(dynamic_pages)s,
-                       'use_services': '%(use_services)s',
-                       'basecourse': project_name,
-                       'course_id': project_name,
-                       # These are used for non-dynamic books.
-                       'appname': 'runestone',
-                       'course_url': master_url,
-                      }
+        template_args={
+            'login_required': '%(login_req)s',
+            'loglevel': %(log_level)d,
+            'course_title': project_name,
+            'python3': '%(python3)s',
+            'dburl': '%(dburl)s',
+            'default_ac_lang': '%(default_ac_lang)s',
+            'jobe_server': 'http://jobe2.cosc.canterbury.ac.nz',
+            'proxy_uri_runs': '/jobe/index.php/restapi/runs/',
+            'proxy_uri_files': '/jobe/index.php/restapi/files/',
+            'downloads_enabled': '%(downloads_enabled)s',
+            'enable_chatcodes': '%(enable_chatcodes)s',
+            'allow_pairs': '%(allow_pairs)s',
+            'dynamic_pages': %(dynamic_pages)s,
+            'use_services': '%(use_services)s',
+            'basecourse': project_name,
+            'course_id': project_name,
+            # These are used for non-dynamic books.
+            'appname': 'runestone',
+            'course_url': master_url,
+        }
     )
 )
 
@@ -65,5 +68,3 @@ options.build.template_args['runestone_version'] = version
 
 # If DBURL is in the environment override dburl
 options.build.template_args['dburl'] = get_dburl(outer=locals())
-
-from runestone import build  # build is called implicitly by the paver driver.


### PR DESCRIPTION
This is some cleanup, but I'm not trying to change any functionality.

On line 41, we set `dburl`. Then, on line 70, that value is overridden. Why set it at all?