### PR TITLE
Clarify difference between RunestoneServer and `runestone serve`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,14 +77,11 @@ To build the included default project run
 
     runestone build
 
-You will now have a build folder with a file index.html in it, along with some default content.  The contents of the build folder are suitable for hosting anywhere that you can serve static web content from!  For a small class you could even serve the content using the builtin Python webserver.
-
 *Note:* If you come across version conflict with ``six`` library while building the project, ``pip install --ignore-installed six`` command might be useful.
 
-::
+You will now have a build folder with a file index.html in it, along with some default content.  The contents of the build folder are suitable for hosting anywhere that you can serve static web content from!  For a small class you could even serve the content using the provided Python webserver::
 
     $ runestone serve
-
 
 Now from your browser you can open up ``http://localhost:8000/index.html``  You should see the table of contents for a sample page like this:
 

--- a/runestone/__main__.py
+++ b/runestone/__main__.py
@@ -126,6 +126,9 @@ def build(all, wd):
 @click.option('--port', default=8000, help="port for server to listen on")
 @click.option('--listen', default="", help="address for server to listen on")
 def serve(port,listen):
+    click.echo("Note: this is a minimal static server without templates or a database.")
+    click.echo("For many use cases this is fine.")
+    click.echo("For the full server, see https://github.com/RunestoneInteractive/RunestoneServer")
     os.chdir(findProjectRoot())
     sys.path.insert(0,os.getcwd())
     try:


### PR DESCRIPTION
Based on the discussion in https://github.com/RunestoneInteractive/fopp/issues/269. Closes #931.

Maybe it's just me, but when I read the README, I interpreted "the builtin Python webserver" to mean something like `python -m http.server`. I didn't mentally link it to the command beneath. Hopefully a colon and moving that warning about six out of the way fixes that.

But I've put the main clarification in the command because one should generally assume that people don't read the docs.

There's probably more that can be done in this area. There's so many repositories and pages and it's hard to see how it all fits together. Further down it says:

> (See the RunestoneServer repository and http://runestoneinteractive.org for more complete documentation on how this project works.)

but the first thing I see then is the blog, and I don't know which page I'm meant to be opening to see the documentation it's referring to.