### PR TITLE
Fix the unpairing distractors problem

### DIFF
--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -1940,12 +1940,6 @@ export default class Parsons extends RunestoneBase {
         }
         originalBlocks = unorderedBlocks;
 
-        /*
-        if (this.recentAttempts < 2) {
-            this.pairDistractors = false;
-        } else {
-            this.pairDistractors = true;
-        }*/
         // Trim the distractors
         var removedBlocks = [];
         if (this.options.maxdist !== undefined) {
@@ -1977,7 +1971,6 @@ export default class Parsons extends RunestoneBase {
             }
         }
         if (this.options.order === undefined) {
-            console.log(unorderedBlocks);
             // Shuffle, respecting paired distractors
             var chunks = [],
                 chunk = [];
@@ -2004,7 +1997,6 @@ export default class Parsons extends RunestoneBase {
                     blocks.push(chunk[0]);
                 }
             }
-            console.log(blocks);
         } else {
             // Order according to order specified
             for (i = 0; i < this.options.order.length; i++) {

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -1465,6 +1465,7 @@ export default class Parsons extends RunestoneBase {
         var lineNumbers = [];
         var pairedDivs = [];
         var j;
+        // This is add style to paired bins
         if (this.pairDistractors || !this.options.adaptive) {
             for (i = bins.length - 1; i > -1; i--) {
                 bin = bins[i];
@@ -1938,6 +1939,13 @@ export default class Parsons extends RunestoneBase {
             }
         }
         originalBlocks = unorderedBlocks;
+
+        /*
+        if (this.recentAttempts < 2) {
+            this.pairDistractors = false;
+        } else {
+            this.pairDistractors = true;
+        }*/
         // Trim the distractors
         var removedBlocks = [];
         if (this.options.maxdist !== undefined) {
@@ -1969,12 +1977,13 @@ export default class Parsons extends RunestoneBase {
             }
         }
         if (this.options.order === undefined) {
+            console.log(unorderedBlocks);
             // Shuffle, respecting paired distractors
             var chunks = [],
                 chunk = [];
             for (i = 0; i < unorderedBlocks.length; i++) {
                 block = unorderedBlocks[i];
-                if (block.lines[0].paired) {
+                if (block.lines[0].paired && this.pairDistractors) {
                     chunk.push(block);
                 } else {
                     chunk = [];
@@ -1995,6 +2004,7 @@ export default class Parsons extends RunestoneBase {
                     blocks.push(chunk[0]);
                 }
             }
+            console.log(blocks);
         } else {
             // Order according to order specified
             for (i = 0; i < this.options.order.length; i++) {
@@ -2007,7 +2017,7 @@ export default class Parsons extends RunestoneBase {
                 }
             }
         }
-        this.pairDistractors = true;
+        // this.pairDistractors = true;
         if (this.options.adaptive) {
             this.limitDistractors = true;
             blocks = this.adaptBlocks(blocks);

--- a/runestone/parsons/test/_sources/index.rst
+++ b/runestone/parsons/test/_sources/index.rst
@@ -30,6 +30,7 @@ SECTION 1: Parsons Problem
 
 
 Section 2: Labeling
+:::::::::::::::::::::::::::::
 
 * Numbers right
 * Numbers left
@@ -91,3 +92,4 @@ Section 2: Labeling
       return fib(num - 1) + fib(num - 2)
    =====
       return fib(num - 1) * fib(num - 2) #paired
+

--- a/runestone/parsons/test/test_parsons.py
+++ b/runestone/parsons/test/test_parsons.py
@@ -303,6 +303,8 @@ class ParsonsTests(RunestoneTestCase):
         self.assertEqual(b2.get_attribute("class"), "block indentRight")
         self.assertEqual(b3.get_attribute("class"), "block indentRight")
 
+
+
     def wait_for_animation(self, selector):
         is_animation_in_progress = self.is_element_animated(selector)
         while is_animation_in_progress is True:


### PR DESCRIPTION
In the current version, if the user solves the problem for the first time. When he or she clicks the reset button, the distractors will be unpaired and all the blocks will be shuffled. The old version could not shuffle the distractors randomly. 