### PR TITLE
Bug Fixes - Parsons problems heights, widths, and image displays (Vincent Qiu September 2020)

### DIFF
--- a/runestone/parsons/css/parsons.css
+++ b/runestone/parsons/css/parsons.css
@@ -276,6 +276,13 @@
     margin-left: auto;
     margin-right: auto;
 }
+
+.parsons .parsons-img {
+    display: inline-block;
+    text-align: center;
+    width: 100%;
+}
+
 .parsons .parsons-controls {
     max-width: 500pt;
     margin-left: auto;

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -2059,13 +2059,22 @@ export default class Parsons extends RunestoneBase {
                 blocks = [];
             }
         }
+
+        // This is necessary, set the pairDistractors value before blocks get shuffled - William Li (August 2020)
+        if (this.recentAttempts < 2) {
+            // 1 Try
+            this.pairDistractors = false;
+        } else {
+            this.pairDistractors = true;
+        }
+
         if (this.options.order === undefined) {
             // Shuffle, respecting paired distractors
             var chunks = [],
                 chunk = [];
             for (i = 0; i < unorderedBlocks.length; i++) {
                 block = unorderedBlocks[i];
-                if (block.lines[0].paired) {
+                if (block.lines[0].paired && this.pairDistractors) { // William Li (August 2020)
                     chunk.push(block);
                 } else {
                     chunk = [];

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -1201,8 +1201,26 @@ export default class Parsons extends RunestoneBase {
         this.containerDiv.id = this.counterId;
         this.parsTextDiv = document.createElement("div");
         $(this.parsTextDiv).addClass("parsons-text");
-        this.parsTextDiv.innerHTML = this.question.innerHTML;
-        this.containerDiv.appendChild(this.parsTextDiv);
+        // Images within Parsons problem description were bumping things and causing display misalignment
+        // This if-else section moves images to beneath the problem description to fix misalignment 
+        // Also added '.parsons .parsons-img{}' to parsons.css - Vincent Qiu (September 2020)
+        if (this.question.innerHTML.includes("<img")) {
+            var imgString = this.question.innerHTML.substring(this.question.innerHTML.indexOf("<img"),this.question.innerHTML.indexOf(">") + 1);
+            var textWithoutImg = this.question.innerHTML.replace(imgString,'');
+            if (imgString.includes('align="left"')) {
+                imgString = imgString.replace('align="left"','');
+            }
+            this.parsTextDiv.innerHTML = textWithoutImg;
+            this.containerDiv.appendChild(this.parsTextDiv);
+            this.parsImgDiv = document.createElement("div");
+            $(this.parsImgDiv).addClass("parsons-img");
+            this.parsImgDiv.innerHTML = imgString;
+            this.containerDiv.appendChild(this.parsImgDiv);
+        }
+        else {
+            this.parsTextDiv.innerHTML = this.question.innerHTML;
+            this.containerDiv.appendChild(this.parsTextDiv);
+        }
         this.keyboardTip = document.createElement("div");
         $(this.keyboardTip).attr("role", "tooltip");
         this.keyboardTip.id = this.counterId + "-tip";

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -1491,7 +1491,7 @@ export default class Parsons extends RunestoneBase {
                 var maxInnerText;
                 var maxInnerLength = 0;
                 var i;
-                var widthLimit = 500;
+                var widthLimit = 475;
                 var longCount = 0;
                 for (i = 0; i < linesItem[linesIndex].children.length; i++) {
                     pixelsPerIndent = linesItem[linesIndex].children[i].pixelsPerIndent;
@@ -1504,7 +1504,7 @@ export default class Parsons extends RunestoneBase {
                     }
                 }
                 areaWidth = Math.max(areaWidth, maxInnerLength + 40);
-                // Set width limit to 500 and determine how much additional height is needed to accommodate the forced text overflow - Vincent Qiu (September 2020)
+                // Set width limit and determine how much additional height is needed to accommodate the forced text overflow - Vincent Qiu (September 2020)
                 if (areaWidth > widthLimit) {
                     areaWidth = widthLimit;
                     areaHeight += longCount * additionalHeight;


### PR DESCRIPTION
Many Parsons problem areas were displaying with significantly more height than necessary taking up more screen space and with less width than necessary causing lines of text to overflow. Now calculations for Parsons problem areas heights and widths have been reprogrammed within parsons.js to resolve this issue.

Some Parsons problems include images (e.g. https://runestone.academy/runestone/books/published/StudentCSP/CSPRepeatTurtles/patterns.html) that cause misalignment of the problem text and Parsons problem areas. Now images are being checked for and , if found, are being moved to their own <div> within parsons.js, and the new <div> has a corresponding class within parsons.css to resolve this issue.

additional commit on September 18, 2020:
Incorporated William Li's changes to parsons.js from previous pull request: https://github.com/RunestoneInteractive/RunestoneComponents/pull/1051