### PR TITLE
Parsons height width fix to handle different computers rendering different typefaces

### DIFF
--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -1497,7 +1497,7 @@ export default class Parsons extends RunestoneBase {
                 var fontFamily = linesItem[linesIndex].children[0].fontFamily;
                 var tempCanvas = document.createElement("canvas");
                 var tempCanvasCtx = tempCanvas.getContext("2d");
-                tempCanvasCtx.font = fontSize + fontFamily;
+                tempCanvasCtx.font = fontSize + " " + fontFamily;
 
                 // Increment Parsons area height based on number of lines of text in the current Parsons block - Vincent Qiu (September 2020)
                 var singleHeight = 40;

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -251,9 +251,29 @@ class ParsonsLine {
         // Pass this information on to be used in class Parsons function initializeAreas
         // to manually determine appropriate widths - Vincent Qiu (September 2020)
         this.view.fontSize = window.getComputedStyle(this.view, null).getPropertyValue('font-size');
-        this.view.fontFamily = window.getComputedStyle(this.view, null).getPropertyValue('font-family');
         this.view.pixelsPerIndent = this.problem.options.pixelsPerIndent;
         this.view.indent = this.indent;
+
+        // Figure out which typeface will be rendered by comparing text widths to browser default - Vincent Qiu (September 2020)
+        var tempCanvas = document.createElement("canvas");
+        var tempCanvasCtx = tempCanvas.getContext("2d");
+        var possibleFonts = window.getComputedStyle(this.view, null).getPropertyValue('font-family').split(", ");
+        var fillerText = "abcdefghijklmnopqrstuvwxyz0123456789,./!@#$%^&*-+";
+        tempCanvasCtx.font = this.view.fontSize + " serif";
+        var serifWidth = tempCanvasCtx.measureText(fillerText).width;
+        for (var i = 0; i < possibleFonts.length; i++) {
+            if (possibleFonts[i].includes('"')) {
+                possibleFonts[i] = possibleFonts[i].replaceAll('"',"");
+            }
+            if (possibleFonts[i].includes("'")) {
+                possibleFonts[i] = possibleFonts[i].replaceAll("'","");
+            }
+            tempCanvasCtx.font = this.view.fontSize + " " + possibleFonts[i];
+            if (tempCanvasCtx.measureText(fillerText).width !== serifWidth) {
+                this.view.fontFamily = possibleFonts[i];
+                break;
+            }
+        }
     }
     // Answer the block that this line is currently in
     block() {
@@ -1472,9 +1492,9 @@ export default class Parsons extends RunestoneBase {
                     }
                 }
 
-                // Create a canvas and set the passed through fontSize and fontFamily in order to later measure text width - Vincent Qiu (September 2020)
+                // Create a canvas and set the passed through fontSize and fontFamily in order to measure text width - Vincent Qiu (September 2020)
                 var fontSize = linesItem[linesIndex].children[0].fontSize;
-                var fontFamily = linesItem[linesIndex].children[0].fontFamily.split(",")[2];
+                var fontFamily = linesItem[linesIndex].children[0].fontFamily;
                 var tempCanvas = document.createElement("canvas");
                 var tempCanvasCtx = tempCanvas.getContext("2d");
                 tempCanvasCtx.font = fontSize + fontFamily;


### PR DESCRIPTION
Previously manual calculation of Parsons heights and widths was built to only address one typeface, but different computers may render different typefaces along the priority list of `Menlo, Monaco, Consolas, "Courier New", monospace;` as set in bootstrap.css. Additional code has been added to determine which typeface will be rendered by the computer and then set that typeface to be used for calculating Parsons heights and widths.