### PR TITLE
Invert default setting of providing feedback on timed assignments to be no feedback

### DIFF
--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -1516,7 +1516,7 @@ export default class Parsons extends RunestoneBase {
                 // Increment Parsons area height based on number of lines of text in the current Parsons block - Vincent Qiu (September 2020)
                 var singleHeight = 40;
                 var additionalHeight = 20;
-                areaHeight += Math.ceil(
+                areaHeight += Math.ceil( // For future more accurate height display, this calculation should also be conditionally based on fontFamily
                     singleHeight +
                         (linesItem[linesIndex].children.length - 1) *
                             additionalHeight +
@@ -1542,7 +1542,7 @@ export default class Parsons extends RunestoneBase {
                                 linesItem[linesIndex].children[i].innerText
                             ).width
                     );
-                    longCount += Math.floor(itemLength / widthLimit);
+                    longCount += Math.floor(itemLength / (widthLimit - 29));
                     if (itemLength > maxInnerLength) {
                         maxInnerText =
                             linesItem[linesIndex].children[i].innerText;

--- a/runestone/timed/js/timed.js
+++ b/runestone/timed/js/timed.js
@@ -38,9 +38,9 @@ export default class Timed extends RunestoneBase {
             this.startingTime = this.timeLimit;
             this.limitedTime = true;
         }
-        this.showFeedback = true;
+        this.showFeedback = false;
         if ($(this.origElem).is("[data-no-feedback]")) {
-            this.showFeedback = false;
+            this.showFeedback = true;
         }
         this.showResults = true;
         if ($(this.origElem).is("[data-no-result]")) {


### PR DESCRIPTION
Require instructor to check the Feedback box in order for students to receive feedback on timed assignments because in the assessment setting, accidentally neglecting the Feedback option in assignment setup and defaulting to provide feedback could pose an academic integrity issue.

This change is in coordination with a change in RunestoneServer:
https://github.com/RunestoneInteractive/RunestoneServer/pull/1554