### PR TITLE
Add poll functionality - display all response option results, display count, move smaller percents outside of bar

### DIFF
--- a/runestone/poll/js/poll.js
+++ b/runestone/poll/js/poll.js
@@ -176,18 +176,37 @@ export default class Poll extends RunestoneBase {
             );
             var list = $(document.createElement("div"));
             $(list).addClass("results-container");
-            for (var i = 0; i < opt_list.length; i++) {
-                var count = count_list[i];
-                var percent = (count / total) * 100;
-                var text = Math.round(10 * percent) / 10 + "%"; // round percent to 10ths
-                var html =
-                    `<div class="progresscounter">${i + 1}. </div>` +
-                    "<div class='progress'>" +
-                    "<div class='progress-bar progress-bar-success'" +
-                    `style="width: ${percent}%; min-width: 2em;">` +
-                    "<span class='poll-text'>" +
-                    text +
-                    "</span></div></div>";
+            for (var i = 0; i < this.optionList.length; i++) {
+                var count;
+                var percent;
+                if (count_list[i]) {
+                    count = count_list[i];
+                    percent = (count / total) * 100;
+                } else {
+                    count = 0;
+                    percent = 0;
+                }
+                var text = count + " (" + Math.round(10 * percent) / 10 + "%)"; // round percent to 10ths
+                var html;
+                if (percent > 10) {
+                    html =
+                        `<div class="progresscounter">${i + 1}. </div>` +
+                        "<div class='progress'>" +
+                        "<div class='progress-bar progress-bar-success'" +
+                        `style="width: ${percent}%; min-width: 2em;">` +
+                        "<span class='poll-text'>" +
+                        text +
+                        "</span></div></div>";
+                } else {
+                    html =
+                        `<div class="progresscounter">${i + 1}. </div>` +
+                        "<div class='progress'>" +
+                        "<div class='progress-bar progress-bar-success'" +
+                        `style="width: ${percent}%; min-width: 2em;"></div>` +
+                        "<span class='poll-text' style='margin: 0 0 0 10px;'>" +
+                        text +
+                        "</span></div>";
+                }
                 var el = $(html);
                 list.append(el);
             }


### PR DESCRIPTION
**Display all response option results**
Currently poll results graph only displays results for response options up to the last option that has data:
![image](https://user-images.githubusercontent.com/40499850/101693618-e5f01800-3a3f-11eb-8069-9a9ec3741e59.png)

This has been updated to display results for all response options:
![image](https://user-images.githubusercontent.com/40499850/101693528-be994b00-3a3f-11eb-9b9f-8f271c026df3.png)

**Display count**
Update the results labels to include the discrete response count value in addition to the already existing response percent.

**Move smaller percents outside of bar**
For response options with less than 10% response, their corresponding results labels are moved to the right side of the bar. 