### PR TITLE
Update to current CodeChat to fix docs build in RunestoneServer

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,47 +6,49 @@
 #
 alabaster==0.7.12         # via sphinx
 astroid==2.4.2            # via pylint
+atomicwrites==1.4.0       # via pytest
 attrs==20.3.0             # via pytest
 babel==2.9.0              # via sphinx
-bleach==3.2.1             # via readme-renderer
+bleach==3.3.0             # via readme-renderer
 certifi==2020.12.5        # via requests
 chardet==4.0.0            # via requests
 click==7.1.2              # via -r requirements.in, pip-tools
-codechat==1.8.3           # via -r requirements.in
+codechat==1.8.6           # via -r requirements.in
 cogapp==3.0.0             # via -r requirements.in
-colorama==0.4.4           # via twine
+colorama==0.4.4           # via pylint, pytest, sphinx, twine
 docutils==0.16            # via codechat, readme-renderer, sphinx
 easyprocess==0.3          # via pyvirtualdisplay
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
 iniconfig==1.1.1          # via pytest
-isort==5.6.4              # via pylint
-jinja2==2.11.2            # via sphinx
-keyring==21.5.0           # via twine
+isort==5.7.0              # via pylint
+jinja2==2.11.3            # via sphinx
+keyring==22.0.1           # via twine
 lazy-object-proxy==1.4.3  # via astroid
 lxml==4.6.2               # via codechat
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
-packaging==20.8           # via bleach, pytest, sphinx
+packaging==20.9           # via bleach, pytest, sphinx
 paver==1.3.4              # via -r requirements.in, sphinxcontrib-paverutils
-pip-tools==5.4.0          # via -r requirements-dev.in
-pkginfo==1.6.1            # via twine
+pip-tools==5.5.0          # via -r requirements-dev.in
+pkginfo==1.7.0            # via twine
 pluggy==0.13.1            # via pytest
 py==1.10.0                # via pytest
-pygments==2.7.3           # via codechat, readme-renderer, sphinx
+pygments==2.7.4           # via codechat, readme-renderer, sphinx
 pylint==2.6.0             # via -r requirements-dev.in
 pyparsing==2.4.7          # via packaging
-pytest==6.2.1             # via -r requirements-dev.in
-pytz==2020.4              # via babel
-pyvirtualdisplay==1.3.2   # via -r requirements-dev.in
+pytest==6.2.2             # via -r requirements-dev.in
+pytz==2021.1              # via babel
+pyvirtualdisplay==2.0     # via -r requirements-dev.in
+pywin32-ctypes==0.2.0     # via keyring
 readme-renderer==28.0     # via -r requirements-dev.in, twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.25.1          # via requests-toolbelt, sphinx, twine
 rfc3986==1.4.0            # via twine
 selenium==3.141.0         # via -r requirements-dev.in
-six==1.15.0               # via -r requirements.in, astroid, bleach, paver, pip-tools, readme-renderer
-snowballstemmer==2.0.0    # via sphinx
-sphinx==3.3.1             # via -r requirements.in, sphinxcontrib-paverutils
+six==1.15.0               # via -r requirements.in, astroid, bleach, paver, readme-renderer
+snowballstemmer==2.1.0    # via sphinx
+sphinx==3.4.3             # via -r requirements.in, sphinxcontrib-paverutils
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -54,11 +56,11 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-paverutils==1.17.0  # via -r requirements.in
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-sqlalchemy==1.3.21        # via -r requirements.in
+sqlalchemy==1.3.23        # via -r requirements.in
 toml==0.10.2              # via pylint, pytest
-tqdm==4.54.1              # via twine
-twine==3.2.0              # via -r requirements-dev.in
-urllib3==1.26.2           # via requests, selenium
+tqdm==4.56.0              # via twine
+twine==3.3.0              # via -r requirements-dev.in
+urllib3==1.26.3           # via requests, selenium
 webencodings==0.5.1       # via bleach
 wheel==0.36.2             # via -r requirements-dev.in
 wrapt==1.12.1             # via astroid

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,4 @@ Sphinx>=2.0.0
 sphinxcontrib-paverutils>=1.17
 cogapp>=2.5
 SQLAlchemy>=1.0.13
-CodeChat>=1.8.2
+CodeChat>=1.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,23 +9,24 @@ babel==2.9.0              # via sphinx
 certifi==2020.12.5        # via requests
 chardet==4.0.0            # via requests
 click==7.1.2              # via -r requirements.in
-codechat==1.8.3           # via -r requirements.in
+codechat==1.8.6           # via -r requirements.in
 cogapp==3.0.0             # via -r requirements.in
+colorama==0.4.4           # via sphinx
 docutils==0.16            # via codechat, sphinx
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-jinja2==2.11.2            # via sphinx
+jinja2==2.11.3            # via sphinx
 lxml==4.6.2               # via codechat
 markupsafe==1.1.1         # via jinja2
-packaging==20.8           # via sphinx
+packaging==20.9           # via sphinx
 paver==1.3.4              # via -r requirements.in, sphinxcontrib-paverutils
-pygments==2.7.3           # via codechat, sphinx
+pygments==2.7.4           # via codechat, sphinx
 pyparsing==2.4.7          # via packaging
-pytz==2020.4              # via babel
+pytz==2021.1              # via babel
 requests==2.25.1          # via sphinx
 six==1.15.0               # via -r requirements.in, paver
-snowballstemmer==2.0.0    # via sphinx
-sphinx==3.3.1             # via -r requirements.in, sphinxcontrib-paverutils
+snowballstemmer==2.1.0    # via sphinx
+sphinx==3.4.3             # via -r requirements.in, sphinxcontrib-paverutils
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -33,8 +34,8 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-paverutils==1.17.0  # via -r requirements.in
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-sqlalchemy==1.3.21        # via -r requirements.in
-urllib3==1.26.2           # via requests
+sqlalchemy==1.3.23        # via -r requirements.in
+urllib3==1.26.3           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
I updated all dependencies while I was at it.

This has to be merged, then released, then we can update the requirements for RunestoneServer, which will finally fix the docs build problem.