### PR TITLE
[Draft PR] Select question :toggle: functionality for debugging active code "Save & Run" button

### DIFF
--- a/runestone/selectquestion/js/selectone.js
+++ b/runestone/selectquestion/js/selectone.js
@@ -162,9 +162,6 @@ export default class SelectOne extends RunestoneBase {
                 toggleFirstID = toggleFirstID.split('"')[0];
                 htmlsrc = toggleUI + htmlsrc + '</div>';
             }
-            console.log(self);
-            console.log(data);
-            console.log(this);
             ///////////////////////////
             // just render this component on the page in its usual place
             res = renderRunestoneComponent(htmlsrc, selectorId, {
@@ -183,7 +180,7 @@ export default class SelectOne extends RunestoneBase {
                 }
                 toggleQuestionSelect.addEventListener("change", async function () {
                     await this.togglePreview(toggleQuestionSelect.parentElement.id);
-                });
+                }.bind(this));
             }
             ///////////////////////////
         }
@@ -228,18 +225,11 @@ export default class SelectOne extends RunestoneBase {
         $(setButton).addClass("btn btn-primary");
         $(setButton).click(async function () {
             await this.toggleSet(parentID, selectedQuestion, htmlsrc)
-        });
+        }.bind(this));
         $("#component-preview").append(setButton);
     }
 
     async toggleSet(parentID, selectedQuestion, htmlsrc) {
-        console.log("within toggleSet function");
-        console.log("parentID is " + parentID);
-        console.log("selectedQuestion is " + selectedQuestion);
-        console.log("----------");
-        console.log(self);
-        console.log(data);
-        console.log(this);
         var selectorId = parentID + "-toggleSelectedQuestion";
         document.getElementById(selectorId).innerHTML = ""; // need to check whether this is even necessary
         let res = renderRunestoneComponent(htmlsrc, selectorId, {
@@ -252,14 +242,9 @@ export default class SelectOne extends RunestoneBase {
 
             }
         );
-        console.log(request);
         let response = await fetch(request);
-        console.log(response);
         $("#component-preview").html("");
         $("#" + parentID).data("toggle_current", selectedQuestion);
-        var toggleQuestions =  document.getElementById(parentID).getElementsByTagName("select")[0];
-        var selectedQuestion = toggleQuestions.options[toggleQuestions.selectedIndex].text;
-        // alert("Problem " + parentID + " has been switched to " + selectedQuestion + ".");
     }
 }
 

--- a/runestone/selectquestion/js/selectone.js
+++ b/runestone/selectquestion/js/selectone.js
@@ -38,6 +38,8 @@ export default class SelectOne extends RunestoneBase {
         this.selector_id = $(opts.orig).first().attr("id");
         this.primaryOnly = $(opts.orig).data("primary");
         this.ABExperiment = $(opts.orig).data("ab");
+        this.toggle = $(opts.orig).data("toggle");
+        this.toggle_first = $(opts.orig).data("toggle_first");
         opts.orig.id = this.selector_id;
     }
     /**
@@ -76,6 +78,10 @@ export default class SelectOne extends RunestoneBase {
         if (this.ABExperiment) {
             data.AB = this.ABExperiment;
         }
+        if (this.toggle) {
+            data.toggle = this.toggle;
+            data.toggle_first = this.toggle_first;
+        }
         let opts = this.origOpts;
         let selectorId = this.selector_id;
         console.log("getting question source");
@@ -113,11 +119,72 @@ export default class SelectOne extends RunestoneBase {
             self.containerDiv = res.question.containerDiv;
             self.realComponent.selectorId = selectorId;
         } else {
+            ///////////////////////////
+            if (data.toggle) {
+                var toggleQuestions = this.questions.split(", ");
+                var toggleUI = "";
+                if (!(document.getElementById("component-preview"))) {
+                    toggleUI += '<div id="component-preview" class="col-md-6" style="z-index: 999;"></div>';
+                }
+                toggleUI += '<label for="' + selectorId + '-toggleQuestion">Toggle Question:</label><select id="' + selectorId + '-toggleQuestion">';
+                var i;
+                var toggleQuestionHTMLSrc;
+                var toggleQuestionSubstring;
+                var toggleQuestionType;
+                for (i = 0; i < toggleQuestions.length; i++) {
+                    toggleQuestionHTMLSrc = await getToggleSrc(toggleQuestions[i]);
+                    toggleQuestionSubstring = toggleQuestionHTMLSrc.split('data-component="')[1];
+                    switch (toggleQuestionSubstring.substring(0, toggleQuestionSubstring.indexOf('"'))) {
+                        case ("activecode"):
+                            toggleQuestionType = "Active Code";
+                            break;
+                        case ("clickablearea"):
+                            toggleQuestionType = "Clickable Area";
+                            break;
+                        case ("dragndrop"):
+                            toggleQuestionType = "Drag n Drop";
+                            break;
+                        case ("fillintheblank"):
+                            toggleQuestionType = "Fill in the Blank";
+                            break;
+                        case ("multiplechoice"):
+                            toggleQuestionType = "Multiple Choice";
+                            break;
+                        case ("parsons"):
+                            toggleQuestionType = "Parsons";
+                            break;
+                        case ("shortanswer"):
+                            toggleQuestionType = "Short Answer";
+                            break;
+                    }
+                    toggleUI += '<option value="' + toggleQuestions[i] + '">' + toggleQuestionType + " - " + toggleQuestions[i] + '</option>';
+                }
+                toggleUI += '</select><div id="' + selectorId + '-toggleSelectedQuestion">';
+                var toggleFirstID = htmlsrc.split('id="')[1];
+                toggleFirstID = toggleFirstID.split('"')[0];
+                htmlsrc = toggleUI + htmlsrc + '</div>';
+            }
+            ///////////////////////////
             // just render this component on the page in its usual place
             res = renderRunestoneComponent(htmlsrc, selectorId, {
                 selector_id: selectorId,
                 useRunestoneServices: true,
             });
+            ///////////////////////////
+            if (data.toggle) {
+                var toggleQuestionSelect = document.getElementById(selectorId + "-toggleQuestion");
+                for (i = 0; i < toggleQuestionSelect.options.length; i++) {
+                    if (toggleQuestionSelect.options[i].value == toggleFirstID) {
+                        toggleQuestionSelect.value = toggleFirstID;
+                        $("#" + selectorId).data("toggle_current", toggleFirstID);
+                        break;
+                    }
+                }
+                toggleQuestionSelect.addEventListener("change", function(){
+                    togglePreview(toggleQuestionSelect.parentElement.id)
+                });
+            }
+            ///////////////////////////
         }
         return response;
     }
@@ -145,3 +212,70 @@ $(document).bind("runestone:login-complete", async function () {
         }
     }
 });
+
+// declare as async function; then use fetch instead of using getJSON - await fetch("/runestone/admin/htmlsrc") - see example in RunestoneComponents; then call await getToggleSrc so that it will wait for htmlsrc to be retrieved before proceeding
+async function getToggleSrc(toggleQuestionID) {
+    let request = new Request(
+        "/runestone/admin/htmlsrc?acid=" + toggleQuestionID,
+        {
+            method: "GET",
+        }
+    );
+    let response = await fetch(request);
+    let data = await response.text();
+    var htmlsrc = data.substring(1, data.length - 1);
+    htmlsrc = htmlsrc.replace(/\\n/g, "");
+    htmlsrc = htmlsrc.replace(/\\/g, "");
+    return htmlsrc;
+}
+
+async function togglePreview(parentID) {
+    var parentDiv = document.getElementById(parentID);
+    var toggleQuestionSelect =  parentDiv.getElementsByTagName("select")[0];
+    var selectedQuestion = toggleQuestionSelect.options[toggleQuestionSelect.selectedIndex].value;
+    var htmlsrc = await getToggleSrc(selectedQuestion);
+    let res = renderRunestoneComponent(htmlsrc, "component-preview", {
+        selector_id: "component-preview",
+        useRunestoneServices: true,
+    });
+    // let pd = document.getElementById(preview_div);
+    // pd.appendChild(renderGradingComponents(sid, selectedQuestion));
+
+    let closeButton = document.createElement("button");
+    $(closeButton).text("Close Preview");
+    $(closeButton).addClass("btn btn-default");
+    $(closeButton).click(function (event) {
+        $("#component-preview").html("");
+        toggleQuestionSelect.value = $("#" + parentID).data("toggle_current");
+    });
+    $("#component-preview").append(closeButton);
+
+    let setButton = document.createElement("button");
+    $(setButton).text("Select this Problem");
+    $(setButton).addClass("btn btn-primary");
+    $(setButton).click(function () {
+        toggleSet(parentID, selectedQuestion, htmlsrc)
+    });
+    $("#component-preview").append(setButton);
+}
+
+async function toggleSet(parentID, selectedQuestion, htmlsrc) {
+    var selectorId = parentID + "-toggleSelectedQuestion";
+    document.getElementById(selectorId).innerHTML = ""; // need to check whether this is even necessary
+    let res = renderRunestoneComponent(htmlsrc, selectorId, {
+        selector_id: selectorId,
+        useRunestoneServices: true,
+    });
+    let request = new Request(
+        "/runestone/ajax/update_selected_question?metaid=" + parentID + "&selected=" + selectedQuestion,
+        {
+
+        }
+    );
+    let response = await fetch(request);
+    $("#component-preview").html("");
+    $("#" + parentID).data("toggle_current", selectedQuestion);
+    var toggleQuestions =  document.getElementById(parentID).getElementsByTagName("select")[0];
+    var selectedQuestion = toggleQuestions.options[toggleQuestions.selectedIndex].text;
+    // alert("Problem " + parentID + " has been switched to " + selectedQuestion + ".");
+}

--- a/runestone/selectquestion/selectone.py
+++ b/runestone/selectquestion/selectone.py
@@ -48,7 +48,7 @@ from runestone.common.runestonedirective import (
 
 TEMPLATE = """
 <div class="runestone alert alert-warning sqcontainer">
-<div data-component="selectquestion" id={component_id} {selector} {points} {proficiency} {min_difficulty} {max_difficulty} {autogradable} {not_seen_ever} {primary} {AB}>
+<div data-component="selectquestion" id={component_id} {selector} {points} {proficiency} {min_difficulty} {max_difficulty} {autogradable} {not_seen_ever} {primary} {AB} {toggle} {toggle_first}>
     <p>Loading ...</p>
 </div>
 </div>
@@ -71,6 +71,7 @@ class SelectQuestion(RunestoneIdDirective):
        :min_difficulty: minimum difficulty level
        :max_difficulty: maximum difficulty level
        :ab: experiment_name
+       :toggle: allow student to choose which question to answer from the given list, and entering a question ID here will make that question display initially
 
        Difficulty is measured in one of two ways. For things like multiple choice and
        fill in the blank, we can use the % of students that get the answer correct on
@@ -79,7 +80,7 @@ class SelectQuestion(RunestoneIdDirective):
     """
 
     required_arguments = 1
-    optional_arguments = 0
+    optional_arguments = 1
     has_content = False
     option_spec = RunestoneIdDirective.option_spec.copy()
     option_spec.update(
@@ -93,6 +94,7 @@ class SelectQuestion(RunestoneIdDirective):
             "not_seen_ever": directives.flag,
             "primary": directives.flag,
             "ab": directives.unchanged,
+            "toggle": directives.unchanged,
         }
     )
 
@@ -179,6 +181,13 @@ class SelectQuestion(RunestoneIdDirective):
             self.options["AB"] = f"data-ab={self.options['ab']}"
         else:
             self.options["AB"] = ""
+
+        if "toggle" in self.options:
+            self.options["toggle_first"] = f"data-toggle_first={self.options['toggle']}"
+            self.options["toggle"] = "data-toggle=true"
+        else:
+            self.options["toggle"] = ""
+            self.options["toggle_first"] = ""
 
         maybeAddToAssignment(self)
 

--- a/runestone/selectquestion/selectone.py
+++ b/runestone/selectquestion/selectone.py
@@ -48,7 +48,7 @@ from runestone.common.runestonedirective import (
 
 TEMPLATE = """
 <div class="runestone alert alert-warning sqcontainer">
-<div data-component="selectquestion" id={component_id} {selector} {points} {proficiency} {min_difficulty} {max_difficulty} {autogradable} {not_seen_ever} {primary} {AB} {toggle} {toggle_first}>
+<div data-component="selectquestion" id={component_id} {selector} {points} {proficiency} {min_difficulty} {max_difficulty} {autogradable} {not_seen_ever} {primary} {AB} {toggle}>
     <p>Loading ...</p>
 </div>
 </div>
@@ -71,7 +71,7 @@ class SelectQuestion(RunestoneIdDirective):
        :min_difficulty: minimum difficulty level
        :max_difficulty: maximum difficulty level
        :ab: experiment_name
-       :toggle: allow student to choose which question to answer from the given list, and entering a question ID here will make that question display initially
+       :toggle: allow student to choose which question to answer from the given list, with first question in fromid list being rendered first
 
        Difficulty is measured in one of two ways. For things like multiple choice and
        fill in the blank, we can use the % of students that get the answer correct on
@@ -94,7 +94,7 @@ class SelectQuestion(RunestoneIdDirective):
             "not_seen_ever": directives.flag,
             "primary": directives.flag,
             "ab": directives.unchanged,
-            "toggle": directives.unchanged,
+            "toggle": directives.flag,
         }
     )
 
@@ -183,11 +183,9 @@ class SelectQuestion(RunestoneIdDirective):
             self.options["AB"] = ""
 
         if "toggle" in self.options:
-            self.options["toggle_first"] = f"data-toggle_first={self.options['toggle']}"
             self.options["toggle"] = "data-toggle=true"
         else:
             self.options["toggle"] = ""
-            self.options["toggle_first"] = ""
 
         maybeAddToAssignment(self)
 


### PR DESCRIPTION
This is a draft pull request to take a look into why active code questions included in select `:toggle:` are rendering with `"Run"` button instead of `"Save & Run"` button.

This functionality was programmed to address https://github.com/RunestoneInteractive/rs/issues/78

-------------------------------------------------------

.rst syntax for a select `:toggle:` question using the programming contained within this pull request would look something like this:
```
.. selectquestion:: toggleselectpreexisting
    :fromid: qalm_5, ch8ex5muc, ch8Ex5q
    :toggle: qalm_5
```
where the text following the `:toggle:` flag can either be
- populated with a question ID from the `:fromid:` list so that this specified question will be rendered first
- left empty so that the first question rendered is randomly selected from the `:fromid:` list

-------------------------------------------------------

Changed files are:
- selectquestion/selectone.py
    - added data attributes of `toggle` and `toggle_first` to handle the expected .rst syntax
- selectquestion/js/selectone.js
    - check for `toggle` data attribute in select question
    - create preview div with buttons "Close Preview" and "Select this Problem"
    - create dropdown menu using `:fromid:` question list
    - dropdown menu `onchange` renders question within preview div using function `togglePreview()`
    - "Select this Problem" renders question within page and updates grader to use the selected question function `toggleSet()`

-------------------------------------------------------

These changes come in conjunction with changes within RunestoneServer https://github.com/RunestoneInteractive/RunestoneServer/pull/1604:
- controllers/ajax.py
    - add `toggle_first` handling to the `get_question_source` function that is called within selectone.js
- controllers/admin.py
    - change `htmlsrc()` authentication from require instructor status to require login so that a student account can access this function that is used in `:toggle:` programming