### PR TITLE
Component creation trigger

### DIFF
--- a/runestone/activecode/js/acfactory.js
+++ b/runestone/activecode/js/acfactory.js
@@ -160,9 +160,9 @@ export default class ACFactory {
 // Page Initialization
 //
 
-$(document).ready(function () {
+$(document).bind("runestone:login-complete", function () {
     ACFactory.createScratchActivecode();
-    $("[data-component=activecode]").each(function (index) {
+    $("[data-component=activecode]").each(function () {
         if ($(this).closest("[data-component=timedAssessment]").length == 0) {
             // If this element exists within a timed component, don't render it here
             try {

--- a/runestone/shortanswer/js/shortanswer.js
+++ b/runestone/shortanswer/js/shortanswer.js
@@ -272,8 +272,8 @@ export default class ShortAnswer extends RunestoneBase {
 == Find the custom HTML tags and ==
 ==   execute our code on them    ==
 =================================*/
-$(document).ready(function () {
-    $("[data-component=shortanswer]").each(function (index) {
+$(document).bind("runestone:login-complete", function () {
+    $("[data-component=shortanswer]").each(function () {
         if ($(this).closest("[data-component=timedAssessment]").length == 0) {
             // If this element exists within a timed component, don't render it here
             try {


### PR DESCRIPTION
Fix: Trigger component creation on the runestone login complete event instead of when the document is ready. This follows the trigger for all other components.

This is also a pre-req for dynamically-loaded components -- otherwise, odd things happens when they're first loaded (they run the ready event, even though the document has been ready for a while.)