### PR TITLE
Clean: Move imports to webpack

### DIFF
--- a/runestone/__init__.py
+++ b/runestone/__init__.py
@@ -208,7 +208,6 @@ css_files = [
     "presenter_mode.css",
     "jquery-ui-1.10.3.custom.min.css",
     "bootstrap-sphinx.css",
-    "user-highlights.css",
     "runestone-custom-sphinx-bootstrap.css?v=" + runestone_version,
     "theme-overrides.css",
 ]

--- a/runestone/activecode/js/livecode.js
+++ b/runestone/activecode/js/livecode.js
@@ -1,6 +1,7 @@
 import { ActiveCode } from "./activecode.js";
 import MD5 from "./md5.js";
 import JUnitTestParser from "./extractUnitResults.js";
+import "../../codelens/js/pytutor-embed.bundle.js";
 
 export default class LiveCode extends ActiveCode {
     constructor(opts) {

--- a/runestone/codelens/js/codelens.js
+++ b/runestone/codelens/js/codelens.js
@@ -11,6 +11,8 @@
  return the buttons, but I'm having a hard time thinking of any other use for that besides mine.
  */
 
+import RunestoneBase from "../../common/js/runestonebase.js";
+import "./pytutor-embed.bundle.js";
 import "./../css/pytutor.css";
 
 function attachLoggers(codelens, divid) {

--- a/runestone/codelens/visualizer.py
+++ b/runestone/codelens/visualizer.py
@@ -29,8 +29,6 @@ from runestone.common.runestonedirective import RunestoneIdDirective, RunestoneI
 def setup(app):
     app.add_directive("codelens", Codelens)
 
-    app.add_autoversioned_javascript("pytutor-embed.bundle.js")
-
     app.add_config_value("codelens_div_class", "alert alert-warning cd_section", "html")
     app.add_config_value("trace_url", "http://tracer.runestone.academy:5000", "html")
     app.add_node(CodeLensNode, html=(visit_codelens_node, depart_codelens_node))
@@ -40,7 +38,7 @@ def setup(app):
 
 VIS = """
 <div class="runestone" style="max-width: none;">
-    <div class="%(divclass)s" data-question_label="%(question_label)s">
+    <div class="%(divclass)s" data-component="codelens" data-question_label="%(question_label)s">
         <div class="pytutorVisualizer" id="%(divid)s"
            data-params='{"embeddedMode": true, "lang": "%(language)s", "jumpToEnd": false}'>
         </div>

--- a/runestone/common/js/renderComponent.js
+++ b/runestone/common/js/renderComponent.js
@@ -1,6 +1,6 @@
-import TimedMC from "../../mchoice/js/timedmc";
+import { runestone_import } from "../../../webpack.index.js";
 
-export function renderRunestoneComponent(componentSrc, whereDiv, moreOpts) {
+export unction renderRunestoneComponent(componentSrc, whereDiv, moreOpts) {
     /**
      *  The easy part is adding the componentSrc to the existing div.
      *  The tedious part is calling the right functions to turn the

--- a/runestone/common/js/renderComponent.js
+++ b/runestone/common/js/renderComponent.js
@@ -1,6 +1,4 @@
-import { runestone_import } from "../../../webpack.index.js";
-
-export unction renderRunestoneComponent(componentSrc, whereDiv, moreOpts) {
+export function renderRunestoneComponent(componentSrc, whereDiv, moreOpts) {
     /**
      *  The easy part is adding the componentSrc to the existing div.
      *  The tedious part is calling the right functions to turn the

--- a/runestone/common/js/user-highlights.js
+++ b/runestone/common/js/user-highlights.js
@@ -2,12 +2,8 @@
 
 "use strict";
 
-import RunestoneBase from "./runestonebase";
 import "../css/user-highlights.css";
 
-var urlList;
-var extendType;
-var rsb = new RunestoneBase();
 
 function getCompletions() {
     // Get the completion status

--- a/runestone/selectquestion/js/selectone.js
+++ b/runestone/selectquestion/js/selectone.js
@@ -104,7 +104,7 @@ export default class SelectOne extends RunestoneBase {
         if (opts.timed) {
             // timed components are not rendered immediately, only when the student
             // starts the assessment and visits this particular entry.
-            res = await createTimedComponent(htmlsrc, {
+            res = createTimedComponent(htmlsrc, {
                 timed: true,
                 selector_id: selectorId,
                 assessmentTaken: opts.assessmentTaken,
@@ -193,7 +193,7 @@ export default class SelectOne extends RunestoneBase {
             }
             ///////////////////////////
             // just render this component on the page in its usual place
-            await renderRunestoneComponent(htmlsrc, selectorId, {
+            renderRunestoneComponent(htmlsrc, selectorId, {
                 selector_id: selectorId,
                 useRunestoneServices: true,
             });

--- a/runestone/selectquestion/js/selectone.js
+++ b/runestone/selectquestion/js/selectone.js
@@ -6,8 +6,8 @@
 import {
     renderRunestoneComponent,
     createTimedComponent,
-} from "../../common/js/renderComponent";
-import RunestoneBase from "../../common/js/runestonebase";
+} from "../../common/js/renderComponent.js";
+import RunestoneBase from "../../common/js/runestonebase.js";
 import "../css/selectquestion.css";
 
 export default class SelectOne extends RunestoneBase {
@@ -104,7 +104,7 @@ export default class SelectOne extends RunestoneBase {
         if (opts.timed) {
             // timed components are not rendered immediately, only when the student
             // starts the assessment and visits this particular entry.
-            res = createTimedComponent(htmlsrc, {
+            res = await createTimedComponent(htmlsrc, {
                 timed: true,
                 selector_id: selectorId,
                 assessmentTaken: opts.assessmentTaken,
@@ -193,7 +193,7 @@ export default class SelectOne extends RunestoneBase {
             }
             ///////////////////////////
             // just render this component on the page in its usual place
-            res = renderRunestoneComponent(htmlsrc, selectorId, {
+            await renderRunestoneComponent(htmlsrc, selectorId, {
                 selector_id: selectorId,
                 useRunestoneServices: true,
             });


### PR DESCRIPTION
This is another PR moving toward webpack by first cleaning up some JS imports. The goal: move all imports possible to JS, instead of Sphinx `add_javascript` or `add_css_file` methods. This is a first step; eventually, I'd like everything to be in JS includes.

There's also a fix for one component that wasn't labeled with a `data-component` attribute.