### PR TITLE
Clean: removed unused config values.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -158,9 +158,9 @@ rst_prolog = (
 # requires **all** the following:
 #
 # - The use of Runestone services (``eBookConfig.useRunestoneServices === true``)
-# - Logging enabled (``eBookConfig.logLevel > 0``)
+# - Server-side grading to be enabled.
 #
-# The first two conditions cause the ``RunestoneBase.logBookEvent`` in ``runestonebase.js`` to post a student response to the server. The last conditions ensures that ``hsblog`` in ``ajax.py`` on the server will return a response containing grading information.
+# The first condition causes the ``RunestoneBase.logBookEvent`` in ``runestonebase.js`` to post a student response to the server. The second condition ensures that ``hsblog`` in ``ajax.py`` on the server will return a response containing grading information.
 runestone_server_side_grading = False
 
 # Extensions

--- a/public/index.html
+++ b/public/index.html
@@ -54,8 +54,6 @@
             eBookConfig.isLoggedIn = false;
 
             eBookConfig.ajaxURL = eBookConfig.app + "/ajax/";
-            eBookConfig.logLevel = 0;
-            eBookConfig.loginRequired = false;
             eBookConfig.build_info = "4.1.15";
             eBookConfig.python3 = false;
             eBookConfig.acDefaultLanguage = "" ? "" : "python";

--- a/runestone/common/js/runestonebase.js
+++ b/runestone/common/js/runestonebase.js
@@ -88,7 +88,7 @@ export default class RunestoneBase {
         if (this.percent) {
             eventInfo.percent = this.percent;
         }
-        if (eBookConfig.useRunestoneServices && eBookConfig.logLevel > 0) {
+        if (eBookConfig.useRunestoneServices) {
             let request = new Request(eBookConfig.ajaxURL + "hsblog", {
                 method: "POST",
                 headers: this.jsonHeaders,
@@ -136,7 +136,7 @@ export default class RunestoneBase {
         if (this.forceSave || "to_save" in eventInfo === false) {
             eventInfo.save_code = "True";
         }
-        if (eBookConfig.useRunestoneServices && eBookConfig.logLevel > 0) {
+        if (eBookConfig.useRunestoneServices) {
             let request = new Request(eBookConfig.ajaxURL + "runlog.json", {
                 method: "POST",
                 headers: this.jsonHeaders,

--- a/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -257,8 +257,6 @@
     eBookConfig.enableCompareMe = eBookConfig.useRunestoneServices;
   {% endif %}
   eBookConfig.ajaxURL = eBookConfig.app+'/ajax/';
-  eBookConfig.logLevel = {{loglevel}};
-  eBookConfig.loginRequired = {{login_required}};
   eBookConfig.build_info = "{{build_info}}";
   eBookConfig.python3 = {{ python3 }};
   eBookConfig.acDefaultLanguage = '{{ default_ac_lang }}' ? '{{ default_ac_lang }}' : 'python'

--- a/runestone/common/project_template/conf.tmpl
+++ b/runestone/common/project_template/conf.tmpl
@@ -119,9 +119,9 @@ rst_prolog = (
 # requires **all** the following:
 #
 # - The use of Runestone services (``eBookConfig.useRunestoneServices === true``)
-# - Logging enabled (``eBookConfig.logLevel > 0``)
+# - Server-side grading to be enabled.
 #
-# The first two conditions cause the ``RunestoneBase.logBookEvent`` in ``runestonebase.js`` to post a student response to the server. The last conditions ensures that ``hsblog`` in ``ajax.py`` on the server will return a response containing grading information.
+# The first condition causes the ``RunestoneBase.logBookEvent`` in ``runestonebase.js`` to post a student response to the server. The second condition ensures that ``hsblog`` in ``ajax.py`` on the server will return a response containing grading information.
 runestone_server_side_grading = %(server_side_grading)s
 
 # Extensions

--- a/runestone/common/project_template/pavement.tmpl
+++ b/runestone/common/project_template/pavement.tmpl
@@ -34,8 +34,6 @@ options(
         outdir=serving_dir,
         confdir=".",
         template_args={
-            'login_required': '%(login_req)s',
-            'loglevel': %(log_level)d,
             'course_title': project_name,
             'python3': '%(python3)s',
             'dburl': '%(dburl)s',


### PR DESCRIPTION
More clean-up tasks: make the configuration for a book simpler where possible. In this case, remove unused or redundant settings:

- The `courses` table has the `login_required` flag, and it's been moved there. Remove it from the Sphinx book config.
- Likewise, `logLevel` is used once in the JS: `if (eBookConfig.useRunestoneServices && eBookConfig.logLevel > 0)`. Remove it, since `useRunestoneServices` can be examined instead of looking at both.