### PR TITLE
Defer js loading to improve page time till first content

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -319,6 +319,12 @@ html_show_sourcelink = False
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 # html_file_suffix = None
 
+# It True, sets js files from Sphinx & Runestone to be loaded with defer attr
+# substantially speeding up page rendering. May cause issues with books that
+# have custom directives or raw html that assume jquery or another library
+# is loaded before body is parsed. 
+html_defer_js = True
+
 # Output file base name for HTML help builder.
 htmlhelp_basename = "PythonCoursewareProjectdoc"
 

--- a/runestone/animation/animation.py
+++ b/runestone/animation/animation.py
@@ -25,7 +25,7 @@ from runestone.common.runestonedirective import RunestoneIdDirective
 
 def setup(app):
     app.add_directive("animation", Animation)
-    app.add_autoversioned_javascript("animationbase.js")
+    app.add_autoversioned_javascript("animationbase.js", defer="")
 
 
 SRC = """

--- a/runestone/animation/chart.html
+++ b/runestone/animation/chart.html
@@ -18,7 +18,8 @@
 //	$("#visualization").gchart({type: 'graphviz', series: [$.gchart.series([20, 50, 30])]});
 // label: '<f0> left | <f1> middle | <f2> right'
 
-$('#visualization').gchart($.gchart.graphviz(true, 
+document.addEventListener('load', (event) => {
+$('#visualization').gchart($.gchart.graphviz(true,
  {
  struct1: {label: '<f0> left |<f1> middle |<f2> right'},
  struct2: {label: '<f0> one|<f1> two'},
@@ -32,6 +33,7 @@ $('#visualization').gchart($.gchart.graphviz(true,
                 node: {shape: 'record'}
         }
 ));
+});
 
 
 // $('#visualization').gchart($.gchart.graphviz(true, 

--- a/runestone/animation/jqchart/gChartBasic.html
+++ b/runestone/animation/jqchart/gChartBasic.html
@@ -8,7 +8,8 @@
 </style>
 <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
 <script type="text/javascript" src="jquery.gchart.js"></script>
-<script type="text/javascript">
+<script>
+document.addEventListener('load', (event) => {
 $(function () {
 	$('#basicGChart').gchart({type: 'line', maxValue: 40,
 		title: 'Weather for|Brisbane, Australia', titleColor: 'green',
@@ -26,6 +27,7 @@ $(function () {
 		$.gchart.axis('right', 0, 200, 50, 'blue', 'left'),
 		$.gchart.axis('right', ['mm'], [50], 'blue', 'left')],
 		legend: 'right'});
+});
 });
 </script>
 </head>

--- a/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -16,6 +16,12 @@
 <!DOCTYPE html>
 {%- endblock %}
 
+{%- block scripts %}
+{# Override the scripts block from sphinx so we can force loading of jquery/underscore/doctools js files #}
+{{ js_defer(script_files) }}
+{{ super() }}
+{%- endblock %}
+
 {# Sidebar: Rework into our Boostrap nav section. #}
 {% macro navBar() %}
 

--- a/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -392,6 +392,10 @@
   {% endif %}
 {% endif %}
 
-<script> runestoneComponents.getSwitch(); </script>
+<script> 
+  document.addEventListener('load', (event) => {
+    runestoneComponents.getSwitch(); 
+  });
+</script>
 
 {% endblock %}

--- a/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/relations.html
+++ b/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/relations.html
@@ -25,6 +25,8 @@
           'delay': { show: 100, hide: 50}
          };
 
-  $('#relations-prev').tooltip(opts);
-  $('#relations-next').tooltip(opts);
+  document.addEventListener('load', (event) => {
+    $('#relations-prev').tooltip(opts);
+    $('#relations-next').tooltip(opts);
+  });
 </script>

--- a/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/subchapter.html
+++ b/runestone/common/project_template/_templates/plugin_layouts/sphinx_bootstrap/subchapter.html
@@ -25,10 +25,10 @@
 {%- endif %}
 
 <script type="text/javascript">
-
+document.addEventListener('load', (event) => {
   $('#relations-prev').tooltip({'placement':'right', 'selector': '', 'delay': { show: 100, hide: 50}});
   $('#relations-next').tooltip({'placement':'left', 'selector': '', 'delay': { show: 100, hide: 50}});
-
+});
 </script>
 
 <script>

--- a/runestone/common/project_template/conf.tmpl
+++ b/runestone/common/project_template/conf.tmpl
@@ -275,6 +275,12 @@ html_show_sourcelink = False
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = None
 
+# It True, sets js files from Sphinx & Runestone to be loaded with defer attr
+# substantially speeding up page rendering. May cause issues with books that
+# have custom directives or raw html that assume jquery or another library
+# is loaded before body is parsed. 
+html_defer_js = True
+
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'PythonCoursewareProjectdoc'
 

--- a/runestone/common/runestonedirective.py
+++ b/runestone/common/runestonedirective.py
@@ -175,8 +175,8 @@ def _add_autoversion(
 
 
 # Convenience method to call ``add_js_file`` using ``add_autoversion``.
-def _add_autoversioned_javascript(self, filename):
-    return self.add_js_file(self.add_autoversion(filename))
+def _add_autoversioned_javascript(self, filename, **kwargs):
+    return self.add_js_file(self.add_autoversion(filename), **kwargs)
 
 
 # Convenience method for calling ``add_css_file`` using ``add_autoversion``.

--- a/runestone/disqus/disqus.py
+++ b/runestone/disqus/disqus.py
@@ -56,9 +56,11 @@ DISQUS_BOX = """\
 """
 
 DISQUS_LINK = """
-<a href="#disqus_thread" class='disqus_thread_link' data-disqus-identifier="%(identifier)s" onclick="%(identifier)s_disqus(this);">Show Comments</a>
-<script type='text/javascript'>
+<a href="#disqus_thread" class="disqus_thread_link" data-disqus-identifier="%(identifier)s" onclick="%(identifier)s_disqus(this);">Show Comments</a>
+<script>
+  document.addEventListener('load', (event) => {
     $("a[data-disqus-identifier='%(identifier)s']").attr('data-disqus-identifier', '%(identifier)s_' + eBookConfig.course);
+  });
 </script>
 """
 

--- a/runestone/lp/lp.py
+++ b/runestone/lp/lp.py
@@ -538,7 +538,7 @@ def setup(
     app.setup_extension("CodeChat.CodeToRestSphinx")
 
     # Supply a fake CSS file to avoid errors, since the CodeChat's CSS will import this.
-    app.add_autoversioned_javascript("html4css1.css")
+    app.add_autoversioned_javascript("html4css1.css", defer="")
 
     # See http://www.sphinx-doc.org/en/stable/extdev/appapi.html#sphinx.application.Sphinx.add_role.
     app.add_role("alink", _alink_role)

--- a/runestone/matrixeq/matrixeq.py
+++ b/runestone/matrixeq/matrixeq.py
@@ -43,7 +43,7 @@ def setup(app):
 
     app.add_autoversioned_stylesheet("matrixeq.css")
 
-    app.add_autoversioned_javascript("matrixeq.js")
+    app.add_autoversioned_javascript("matrixeq.js", defer="")
 
     app.add_node(MatrixEqNode, html=(visit_matrixeq_node, depart_matrixeq_node))
     app.add_node(

--- a/runestone/video/video.py
+++ b/runestone/video/video.py
@@ -48,33 +48,37 @@ POPUP = """\
     <div class='video-play-overlay'></div>
 </a>
 <script>
+  document.addEventListener('load', (event) => {
     jQuery(function ($) {
        $('#%(divid)s_thumb').click(function (e) {
                 $('#%(divid)s').modal();
                 return false;
         });
     });
+  });
 </script>
 
 """
 
 INLINE = """\
 <script>
-   jQuery(function($) {
-      var rb = new RunestoneBase();
-      $('#%(divid)s_thumb').click(function(e) {
-         $('#%(divid)s').show();
-         $('#%(divid)s_thumb').hide();
-         rb.logBookEvent({'event':'video','act':'play','div_id': '%(divid)s'});
-         // Log the run event
-      });
-      $('#%(divid)s video').one("click", function(){
-        this.play();
-      });
-      $('#%(divid)s video').one("play", function(){
-        rb.logBookEvent({'event':'video','act':'play','div_id': '%(divid)s'});
-      });
-   });
+  document.addEventListener('load', (event) => {
+    jQuery(function($) {
+        var rb = new RunestoneBase();
+        $('#%(divid)s_thumb').click(function(e) {
+            $('#%(divid)s').show();
+            $('#%(divid)s_thumb').hide();
+            rb.logBookEvent({'event':'video','act':'play','div_id': '%(divid)s'});
+            // Log the run event
+        });
+        $('#%(divid)s video').one("click", function(){
+            this.play();
+        });
+        $('#%(divid)s video').one("play", function(){
+            rb.logBookEvent({'event':'video','act':'play','div_id': '%(divid)s'});
+        });
+    });
+  });
 </script>
 """
 SOURCE = """<source src="%s" type="video/%s"></source>"""

--- a/runestone/webgldemo/webgldemo.py
+++ b/runestone/webgldemo/webgldemo.py
@@ -47,10 +47,10 @@ def setup(app):
 
     # CodeMirror syntax highlighting for various types of code
 
-    app.add_autoversioned_javascript("webglinteractive.js")
+    app.add_autoversioned_javascript("webglinteractive.js", defer="")
 
     # Javascript for saving files to the client's hard drive
-    app.add_autoversioned_javascript("FileSaver.min.js")
+    app.add_autoversioned_javascript("FileSaver.min.js", defer="")
 
     app.add_node(
         WebglInteractiveNode,


### PR DESCRIPTION
Patch to substantially improve render time of pages.

Improves First Contentful Paint time as measured by Lighthouse in Chrome Dev tools by ~50% by setting all the runestone/sphinx js external <script> tags to load with `defer`. This guarantees that they are all loaded in listed order, but removes them as blocking elements for rendering the page. 

Implemented to be disabled by default. To enable behavior in a book, you must set "html_defer_js = True" in the conf.py of the project.

There are three sets of js files that are handled in slightly different ways:
- Files that are added from modules with add_js (or add_autoversioned_js) now explicitly set the defer attribute and add_autoversioned_js has been modified to pass it on. So any future model can opt out of having its scripts deferred if necessary.
- Bundles made by webpack have defer added to them programatically. 
- The jquery/underscore/docutils files that Sphinx adds have defer added to them programmatically.

The changes could be consolidated somewhat if we just blindly added `defer` to all scripts in script_files before render. But that would rule out particular scripts being added without defer by later code.