### PR TITLE
Fix requirements click

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ certifi==2021.5.30
     # via requests
 charset-normalizer==2.0.3
     # via requests
-click==8.0.1
+click<8.0
     # via
     #   -r requirements.in
     #   pip-tools

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # *********
 # |docname|
 # *********
-click
+click<8.0
 Paver>=1.2.4
 six>1.12
 Sphinx<4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ certifi==2021.5.30
     # via requests
 charset-normalizer==2.0.3
     # via requests
-click==8.0.1
+click<8.0
     # via -r requirements.in
 codechat==1.8.8
     # via -r requirements.in


### PR DESCRIPTION
This is just @bnmnetp's two commits to the bookserver branch applied to master. This keeps `click` below v.8.0, which breaks Celery on the (old) Runestone server:

``` 
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/celery/__main__.py", line 19, in <module>
    main()
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/celery/__main__.py", line 14, in main
    from celery.bin.celery import main as _main
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/celery/bin/celery.py", line 15, in <module>
    from celery.bin.amqp import amqp
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/celery/bin/amqp.py", line 7, in <module>
    from click_repl import register_repl
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/click_repl/__init__.py", line 6, in <module>
    import click._bashcomplete
ModuleNotFoundError: No module named 'click._bashcomplete'
```