### PR TITLE
Fix: Old CSS overrode the width of a sidebar's float from 40% to auto

### DIFF
--- a/runestone/common/css/runestone-custom-sphinx-bootstrap.css
+++ b/runestone/common/css/runestone-custom-sphinx-bootstrap.css
@@ -208,7 +208,7 @@ a {
         margin: 0 3px;
         border-left: 1px solid #f2f2f2;
     }
-    
+
     .navbar-fixed-top .container {
         padding: 0;
     }
@@ -766,11 +766,11 @@ div.flash {
 
 .navLink a {
     display: inline-block;
-    background-color: white; 
-    border-style:solid; 
-    border-color:lightgrey; 
-    border-width:2px; 
-    width:100px; 
+    background-color: white;
+    border-style:solid;
+    border-color:lightgrey;
+    border-width:2px;
+    width:100px;
     height:50px
 }
 
@@ -789,7 +789,7 @@ div.flash {
 }
 
 @media (max-width: 600px) {
-    
+
     .navLink {
         display: inline-block;
         bottom: auto;
@@ -869,9 +869,13 @@ div.flash {
     background-color: #ffffff;
 }
 
-.container .section>div.sidebar {
+.container {
     margin: 0 0 0.5em 1em;
     width: auto;
+}
+
+.section>div.sidebar {
+    margin: 0 0 0.5em 1em;
 }
 
 a.disqus_thread_link {

--- a/runestone/common/css/runestone-custom-sphinx-bootstrap.css
+++ b/runestone/common/css/runestone-custom-sphinx-bootstrap.css
@@ -869,12 +869,7 @@ div.flash {
     background-color: #ffffff;
 }
 
-.container {
-    margin: 0 0 0.5em 1em;
-    width: auto;
-}
-
-.section>div.sidebar {
+.container .section>div.sidebar {
     margin: 0 0 0.5em 1em;
 }
 


### PR DESCRIPTION
The old CSS made `.. sidebar::` elements take the entire line, due to the `width: auto` statement. Removing allows floats to work correctly (the default Sphinx CSS uses `width: 40%`).

Sadly, there's a bit of noise in the diff, since VS Code removed end-of-line whitespace.

# Before
![image](https://user-images.githubusercontent.com/2125584/130328358-8ddf67e5-db95-489f-a1f3-29f80a53cadb.png)

# After
![image](https://user-images.githubusercontent.com/2125584/130328199-df0e478a-8b97-4aa2-a106-8a2d067c5fc6.png)
