### PR TITLE
Fix: Add /ns prefix to ajax paths.

### DIFF
--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -582,7 +582,7 @@ export class ActiveCode extends RunestoneBase {
             // If this is timed and already taken we should restore history info
             this.renderScrubber();
         } else {
-            let request = new Request("/assessment/gethist", {
+            let request = new Request("/ns/assessment/gethist", {
                 method: "POST",
                 headers: this.jsonHeaders,
                 body: JSON.stringify(reqData),

--- a/runestone/common/js/bookfuncs.js
+++ b/runestone/common/js/bookfuncs.js
@@ -171,7 +171,7 @@ async function handlePageSetup() {
         Accept: "application/json",
     });
     let data = { timezoneoffset: new Date().getTimezoneOffset() / 60 };
-    let request = new Request("/logger/set_tz_offset", {
+    let request = new Request("/ns/logger/set_tz_offset", {
         method: "POST",
         body: JSON.stringify(data),
         headers: headers,

--- a/runestone/common/js/runestonebase.js
+++ b/runestone/common/js/runestonebase.js
@@ -93,7 +93,7 @@ export default class RunestoneBase {
             eventInfo.percent = this.percent;
         }
         if (eBookConfig.useRunestoneServices && eBookConfig.logLevel > 0) {
-            let request = new Request("/logger/bookevent", {
+            let request = new Request("/ns/logger/bookevent", {
                 method: "POST",
                 headers: this.jsonHeaders,
                 body: JSON.stringify(eventInfo),
@@ -144,7 +144,7 @@ export default class RunestoneBase {
             eventInfo.save_code = "True";
         }
         if (eBookConfig.useRunestoneServices && eBookConfig.logLevel > 0) {
-            let request = new Request("/logger/runlog", {
+            let request = new Request("/ns/logger/runlog", {
                 method: "POST",
                 headers: this.jsonHeaders,
                 body: JSON.stringify(eventInfo),
@@ -202,7 +202,7 @@ export default class RunestoneBase {
             // and assessmentTaken is true
             if (!eBookConfig.practice_mode && !eBookConfig.peer && this.assessmentTaken) {
                 let request = new Request(
-                    "/assessment/results",
+                    "/ns/assessment/results",
                     {
                         method: "POST",
                         body: JSON.stringify(data),

--- a/runestone/common/js/user-highlights.js
+++ b/runestone/common/js/user-highlights.js
@@ -25,7 +25,7 @@ function getCompletions() {
     var data = { lastPageUrl: currentPathname };
     jQuery
         .ajax({
-            url: "/logger/getCompletionStatus",
+            url: "/ns/logger/getCompletionStatus",
             data: data,
             async: false,
         })
@@ -292,7 +292,7 @@ function processPageState(completionFlag) {
         console.log(e);
     });
     jQuery.ajax({
-        url: "/logger/updatelastpage",
+        url: "/ns/logger/updatelastpage",
         contentType: "application/json; charset=utf-8",
         dataType: "json",
         data: JSON.stringify(data),

--- a/runestone/selectquestion/js/selectone.js
+++ b/runestone/selectquestion/js/selectone.js
@@ -91,7 +91,7 @@ export default class SelectOne extends RunestoneBase {
         let opts = this.origOpts;
         let selectorId = this.selector_id;
         console.log("getting question source");
-        let request = new Request("/assessment/get_question_source", {
+        let request = new Request("/ns/assessment/get_question_source", {
             method: "POST",
             headers: this.jsonHeaders,
             body: JSON.stringify(data),
@@ -268,7 +268,7 @@ export default class SelectOne extends RunestoneBase {
     // retrieve html source of a question, for use in various toggle functionalities
     async getToggleSrc(toggleQuestionID) {
         let request = new Request(
-            "/assessment/htmlsrc?acid=" + toggleQuestionID,
+            "/ns/assessment/htmlsrc?acid=" + toggleQuestionID,
             {
                 method: "GET",
             }
@@ -306,7 +306,7 @@ export default class SelectOne extends RunestoneBase {
         });
         $("#toggle-buttons").append(closeButton);
 
-        // if "lock" is not in toggle options, then allow adding more buttons to the preview panel 
+        // if "lock" is not in toggle options, then allow adding more buttons to the preview panel
         if (!(toggleOptions.includes("lock"))) {
             let setButton = document.createElement("button");
             $(setButton).text("Select this Problem");
@@ -351,7 +351,7 @@ export default class SelectOne extends RunestoneBase {
             useRunestoneServices: true,
         });
         let request = new Request(
-            "/assessment/set_selected_question?metaid=" +
+            "/ns/assessment/set_selected_question?metaid=" +
             parentID +
             "&selected=" +
             selectedQuestion,

--- a/runestone/timed/js/timed.js
+++ b/runestone/timed/js/timed.js
@@ -110,7 +110,7 @@ export default class Timed extends RunestoneBase {
         console.log(sendInfo);
         if (eBookConfig.useRunestoneServices) {
             let request = new Request(
-                "/assessment/tookTimedAssessment",
+                "/ns/assessment/tookTimedAssessment",
                 {
                     method: "POST",
                     headers: this.jsonHeaders,
@@ -296,7 +296,7 @@ export default class Timed extends RunestoneBase {
         this.pagNavList.appendChild(this.rightContainer);
         this.ensureButtonSafety();
         this.navDiv.appendChild(this.pagNavList);
-        this.flagDiv.appendChild(this.flaggingPlace);           // adds flaggingPlace to the flagDiv 
+        this.flagDiv.appendChild(this.flaggingPlace);           // adds flaggingPlace to the flagDiv
         this.break = document.createElement("br");
         this.navDiv.appendChild(this.break);
         // render the question number jump buttons
@@ -393,7 +393,7 @@ export default class Timed extends RunestoneBase {
             "ul#pageNums > ul > li:eq(" + this.currentQuestionIndex + ")"
         ).addClass("active");
         if ($("ul#pageNums > ul > li:eq(" + this.currentQuestionIndex + ")"
-        ).hasClass("flagcolor")) {                                           // checking for class 
+        ).hasClass("flagcolor")) {                                           // checking for class
             this.flagButton.innerHTML = "Unflag Question";                  // changes text on button
         }
         else {


### PR DESCRIPTION
Add the /ns prefix to JS ajax queries.

TESTING ONLY: this doesn't work if the bookserver is running standalone, instead of under nginx. We need to think about some nice way to support both cases.