### PR TITLE
Add: Compress webpage output.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "license": "ISC",
     "devDependencies": {
         "copy-webpack-plugin": "^8.0.0",
+        "compression-webpack-plugin": "^6.0.0",
         "css-loader": "^5.0.0",
         "css-minimizer-webpack-plugin": "^3.0.0",
         "eslint": "^7.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ const path = require("path");
 
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
+const CompressionPlugin = require("compression-webpack-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
@@ -90,6 +91,8 @@ module.exports = (env, argv) => {
                 filename: '[name].css?v=[contenthash]',
                 chunkFilename: '[id].css',
             }),
+            // Copied from the `webpack docs <https://webpack.js.org/plugins/compression-webpack-plugin>`_. This creates ``.gz`` versions of all files. The webserver in use needs to be configured to send this instead of the uncompressed versions.
+            new CompressionPlugin(),
         ],
     };
 };


### PR DESCRIPTION
This is probably the biggest win in terms of reducing bandwith needed for the Runestone Components. Many web servers (including nginx -- `gzip_static on;` in a `http` block) support serving statically compressed files.

Uncompressed, the JS, CSS, and WASM is 7.0 M (`du -hc *.js *.css *.wasm`).
Compressed, the JS, CSS, and WASM is 2.1 M (`du -hc *.js.gz *.css.gz *.wasm.gz`)

We can also look at better compressions schemes (zopfli, etc.), but web server support isn't as consistent. This is an easy fix and a big win.