### PR TITLE
Fix: don't provide client-side feedback for timed exams.

### DIFF
--- a/runestone/fitb/js/fitb.js
+++ b/runestone/fitb/js/fitb.js
@@ -197,9 +197,11 @@ export default class FITB extends RunestoneBase {
             }
         }
         // Grade locally if we can't ask the server to grade.
-        if (this.feedbackArray && !this.isTimed) {
+        if (this.feedbackArray) {
             this.evaluateAnswers();
-            this.renderFeedback();
+            if (!this.isTimed) {
+                this.renderFeedback();
+            }
         }
     }
 
@@ -233,7 +235,9 @@ export default class FITB extends RunestoneBase {
             this.correct = data.correct;
             this.displayFeed = data.displayFeed;
             this.isCorrectArray = data.isCorrectArray;
-            this.renderFeedback();
+            if (!this.isTimed) {
+                this.renderFeedback();
+            }
         }
         return data;
     }

--- a/runestone/fitb/js/fitb.js
+++ b/runestone/fitb/js/fitb.js
@@ -197,7 +197,7 @@ export default class FITB extends RunestoneBase {
             }
         }
         // Grade locally if we can't ask the server to grade.
-        if (this.feedbackArray) {
+        if (this.feedbackArray && !this.isTimed) {
             this.evaluateAnswers();
             this.renderFeedback();
         }


### PR DESCRIPTION
Fixes #1259.

However, this doesn't address the case of server-side feedback, which we should think about.