### PR TITLE
Resolves Issue #1749 of RunestoneServer: Invisible Codelens Print Output in Dark Mode

### DIFF
--- a/runestone/codelens/css/pytutor.css
+++ b/runestone/codelens/css/pytutor.css
@@ -221,7 +221,7 @@ div.ExecutionVisualizer #pyStdout {
   font-size: 12pt;
   padding: 4px;
   font-family: Andale mono, monospace;
-  --bodyFont: #e93f34;
+  color:rgba(24, 20, 235, 0.2);
   overflow: auto; /* to look pretty on IE */
   /* make sure textarea doesn't grow and stretch */
   resize: none;

--- a/runestone/codelens/css/pytutor.css
+++ b/runestone/codelens/css/pytutor.css
@@ -221,7 +221,7 @@ div.ExecutionVisualizer #pyStdout {
   font-size: 12pt;
   padding: 4px;
   font-family: Andale mono, monospace;
-
+  --bodyFont: #e93f34;
   overflow: auto; /* to look pretty on IE */
   /* make sure textarea doesn't grow and stretch */
   resize: none;


### PR DESCRIPTION
Changes color of codelens print output from white to blue, when in dark mode.