### PR TITLE
Clean: Only add webpack package data to the resulting distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,17 @@
 # *********
 # |docname|
 # *********
-graft runestone
+graft runestone/dist
 include requirements.txt
 include README.md
-prune runestone/*/test
-
+# Some of the Runestone Components doesn't use webpack; they still need raw JS/CSS available. See `runestone_static_dirs()`.
+graft runestone/animation/js
+graft runestone/codelens/js
+graft runestone/webgldemo/js
+graft runestone/matrixeq/js
+graft runestone/accessibility/css
+graft runestone/webgldemo/css
+graft runestone/matrixeq/css
+graft runestone/lp/css
+# We need to include the templates used by Sphinx.
+graft runestone/common/project_template

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     package_dir={"runestone": "runestone"},
-    package_data={"": ["js/*.js", "css/*.css", "*.txt"]},
     license="GPL",
     url="https://github.com/RunestoneInteractive/RunestoneComponents",
     download_url="https://github.com/RunestoneInteractive/RunestoneComponents/tarball/{}".format(
@@ -71,9 +70,6 @@ setup(
         "Topic :: Education",
         "Topic :: Text Processing :: Markup",
     ],
-    # data_files=[('common',['runestone/common/*']),
-    #             ('project/template', ['newproject_copy_me/*'])
-    # ],
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
     entry_points={"console_scripts": ["runestone = runestone.__main__:cli"]},


### PR DESCRIPTION
This only puts the required files in the package produced by setup.py. The resulting output went from ~32 MB before this to ~18 MB after.