### PR TITLE
Runestone to PreTeXt

### DIFF
--- a/runestone/activecode/activecode.py
+++ b/runestone/activecode/activecode.py
@@ -53,7 +53,7 @@ def setup(app):
     app.add_config_value("activecode_hide_load_history", False, "html")
     app.add_config_value("wasm_uri", "/_static", "html")
 
-    app.add_node(ActivecodeNode, html=(visit_ac_node, depart_ac_node),
+    app.add_node(ActivecodeNode, html=(visit_ac_html, depart_ac_html),
                  xml=(visit_ac_xml, depart_ac_xml))
 
     app.connect("doctree-resolved", process_activcode_nodes)
@@ -97,12 +97,8 @@ def depart_ac_xml(self, node):
 # self for these functions is an instance of the writer class.  For example
 # in html, self is sphinx.writers.html.SmartyPantsHTMLTranslator
 # The node that is passed as a parameter is an instance of our node class.
-def visit_ac_node(self, node):
+def visit_ac_html(self, node):
     # print self.settings.env.activecodecounter
-
-    # todo:  handle above in node["runestone_options"]
-    # todo handle  'hidecode' not in node["runestone_options"]:
-    # todo:  handle if 'gradebutton' in node["runestone_options"]: res += GRADES
 
     node["delimiter"] = "_start__{}_".format(node["runestone_options"]["divid"])
 
@@ -112,9 +108,9 @@ def visit_ac_node(self, node):
     self.body.append(res)
 
 
-def depart_ac_node(self, node):
+def depart_ac_html(self, node):
     """This is called at the start of processing an activecode node.  If activecode had recursive nodes
-    etc and did not want to do all of the processing in visit_ac_node any finishing touches could be
+    etc and did not want to do all of the processing in visit_ac_html any finishing touches could be
     added here.
     """
     res = TEMPLATE_END % node["runestone_options"]
@@ -451,7 +447,7 @@ class ActiveCode(RunestoneIdDirective):
                     "This should only affect the grading interface. Everything else should be fine."
                 )
 
-        acnode = ActivecodeNode(self.options, rawsource=self.block_text)
+        acnode = ActivecodeNode()
         acnode["runestone_options"] = self.options
         acnode["source"], acnode["line"] = self.state_machine.get_source_and_line(
             self.lineno)

--- a/runestone/assignment/__init__.py
+++ b/runestone/assignment/__init__.py
@@ -36,7 +36,7 @@ from datetime import datetime
 
 def setup(app):
     app.add_directive("assignment", Assignment)
-    app.add_node(AssignmentNode, html=(visit_a_node, depart_a_node))
+    app.add_node(AssignmentNode, html=(visit_a_html, depart_a_html))
 
     app.connect("doctree-resolved", process_nodes)
     app.connect("env-purge-doc", purge)
@@ -54,13 +54,13 @@ class AssignmentNode(nodes.General, nodes.Element, RunestoneNode):
         self.a_components = content
 
 
-def visit_a_node(self, node):
+def visit_a_html(self, node):
     pass
 
 
-def depart_a_node(self, node):
-    question_ids = node.a_components["question_ids"]
-    basecourse = node.a_components["basecourse"]
+def depart_a_html(self, node):
+    question_ids = node["a_components"]["question_ids"]
+    basecourse = node["a_components"]["basecourse"]
     for q_id in question_ids:
         src = get_HTML_from_DB(q_id, basecourse)
         if src:

--- a/runestone/blockly/blockly.py
+++ b/runestone/blockly/blockly.py
@@ -33,7 +33,7 @@ from runestone.common import RunestoneIdDirective, RunestoneIdNode
 def setup(app):
     app.add_directive("blockly", Blockly)
 
-    app.add_node(BlocklyNode, html=(visit_block_node, depart_block_node))
+    app.add_node(BlocklyNode, html=(visit_block_html, depart_block_html))
 
     app.connect("doctree-resolved", process_activcode_nodes)
     app.connect("env-purge-doc", purge_activecodes)
@@ -154,10 +154,12 @@ END = """
 # self for these functions is an instance of the writer class.  For example
 # in html, self is sphinx.writers.html.SmartyPantsHTMLTranslator
 # The node that is passed as a parameter is an instance of our node class.
-def visit_block_node(self, node):
-    res = START % (node.runestone_options)
+
+
+def visit_block_html(self, node):
+    res = START % (node["runestone_options"])
     res += CTRL_START
-    for ctrl in node.runestone_options["controls"]:
+    for ctrl in node["runestone_options"]["controls"]:
         if ctrl == "variables":
             res += '<category name="Variables" custom="VARIABLE"></category>'
         elif ctrl == "":
@@ -169,11 +171,11 @@ def visit_block_node(self, node):
         else:
             res += '<block type="%s"></block>\n' % (ctrl)
     res += CTRL_END
-    res += END % (node.runestone_options)
+    res += END % (node["runestone_options"])
     path = os.path.join(
-        node.runestone_options["blocklyHomePrefix"],
+        node["runestone_options"]["blocklyHomePrefix"],
         "_static",
-        node.runestone_options["divid"] + ".html",
+        node["runestone_options"]["divid"] + ".html",
     )
     final = (
         '<iframe class="blk-iframe" seamless src="%s" width="600" '
@@ -185,9 +187,9 @@ def visit_block_node(self, node):
     self.body.append(final)
 
 
-def depart_block_node(self, node):
+def depart_block_html(self, node):
     """ This is called at the start of processing an activecode node.  If activecode had recursive nodes
-        etc and did not want to do all of the processing in visit_ac_node any finishing touches could be
+        etc and did not want to do all of the processing in visit_ac_html any finishing touches could be
         added here.
     """
     pass

--- a/runestone/cellbotics/__init__.py
+++ b/runestone/cellbotics/__init__.py
@@ -31,7 +31,7 @@ class BlePairNode(nodes.General, nodes.Element):
     pass
 
 
-def visit_ble_pair_node(self, node):
+def visit_ble_pair_html(self, node):
     self.body.append(
         '<div data-component="ble">\n'
         '   <script>runestone_import("ble");</script>\n'
@@ -41,7 +41,7 @@ def visit_ble_pair_node(self, node):
     )
 
 
-def depart_ble_pair_node(self, node):
+def depart_ble_pair_html(self, node):
     pass
 
 
@@ -57,5 +57,5 @@ class BlePairDirective(Directive):
 
 def setup(app):
     # Add the Pair button directive.
-    app.add_node(BlePairNode, html=(visit_ble_pair_node, depart_ble_pair_node))
+    app.add_node(BlePairNode, html=(visit_ble_pair_html, depart_ble_pair_html))
     app.add_directive('ble-pair-button', BlePairDirective)

--- a/runestone/clickableArea/clickable.py
+++ b/runestone/clickableArea/clickable.py
@@ -29,7 +29,7 @@ from runestone.common.runestonedirective import RunestoneIdDirective, RunestoneI
 def setup(app):
     app.add_directive("clickablearea", ClickableArea)
 
-    app.add_node(ClickableAreaNode, html=(visit_ca_node, depart_ca_node))
+    app.add_node(ClickableAreaNode, html=(visit_ca_html, depart_ca_html))
 
     app.add_config_value("clickable_div_class", "runestone alert alert-warning", "html")
 
@@ -46,60 +46,53 @@ TEMPLATE_END = """
 
 
 class ClickableAreaNode(nodes.General, nodes.Element, RunestoneIdNode):
-    def __init__(self, content, **kwargs):
-        """
-        Arguments:
-        - `self`:
-        - `content`:
-        """
-        super(ClickableAreaNode, self).__init__(**kwargs)
-        self.runestone_options = content
+    pass
 
 
 # self for these functions is an instance of the writer class.  For example
 # in html, self is sphinx.writers.html.SmartyPantsHTMLTranslator
 # The node that is passed as a parameter is an instance of our node class.
-def visit_ca_node(self, node):
+def visit_ca_html(self, node):
     res = TEMPLATE
 
-    node.delimiter = "_start__{}_".format(node.runestone_options["divid"])
-    self.body.append(node.delimiter)
+    node["delimiter"] = "_start__{}_".format(node["runestone_options"]["divid"])
+    self.body.append(node["delimiter"])
 
-    if "feedback" in node.runestone_options:
-        node.runestone_options["feedback"] = (
-            "<span data-feedback>" + node.runestone_options["feedback"] + "</span>"
+    if "feedback" in node["runestone_options"]:
+        node["runestone_options"]["feedback"] = (
+            "<span data-feedback>" + node["runestone_options"]["feedback"] + "</span>"
         )
     else:
-        node.runestone_options["feedback"] = ""
+        node["runestone_options"]["feedback"] = ""
 
-    if "iscode" not in node.runestone_options:
-        node.runestone_options["correct"] = (
-            "data-cc=" + '"' + node.runestone_options["correct"] + '"'
+    if "iscode" not in node["runestone_options"]:
+        node["runestone_options"]["correct"] = (
+            "data-cc=" + '"' + node["runestone_options"]["correct"] + '"'
         )
-        node.runestone_options["incorrect"] = (
-            "data-ci=" + '"' + node.runestone_options["incorrect"] + '"'
+        node["runestone_options"]["incorrect"] = (
+            "data-ci=" + '"' + node["runestone_options"]["incorrect"] + '"'
         )
     else:
-        node.runestone_options["correct"] = ""
-        node.runestone_options["incorrect"] = ""
+        node["runestone_options"]["correct"] = ""
+        node["runestone_options"]["incorrect"] = ""
 
-    res = res % node.runestone_options
+    res = res % node["runestone_options"]
 
     self.body.append(res)
 
 
-def depart_ca_node(self, node):
+def depart_ca_html(self, node):
     res = ""
-    res = TEMPLATE_END % node.runestone_options
+    res = TEMPLATE_END % node["runestone_options"]
     self.body.append(res)
 
     addHTMLToDB(
-        node.runestone_options["divid"],
-        node.runestone_options["basecourse"],
-        "".join(self.body[self.body.index(node.delimiter) + 1 :]),
+        node["runestone_options"]["divid"],
+        node["runestone_options"]["basecourse"],
+        "".join(self.body[self.body.index(node["delimiter"]) + 1 :]),
     )
 
-    self.body.remove(node.delimiter)
+    self.body.remove(node["delimiter"])
 
 
 class ClickableArea(RunestoneIdDirective):
@@ -166,11 +159,12 @@ config values (conf.py):
             self.options["clickcode"] = source
         else:
             self.options["clickcode"] = ""
-        clickNode = ClickableAreaNode(self.options, rawsource=self.block_text)
-        clickNode.source, clickNode.line = self.state_machine.get_source_and_line(
+        clickNode = ClickableAreaNode()
+        clickNode["runestone_options"] = self.options
+        clickNode["source"], clickNode["line"] = self.state_machine.get_source_and_line(
             self.lineno
         )
-        clickNode.template_start = TEMPLATE
+        clickNode["template_start"] = TEMPLATE
 
         if "table" in self.options:
             self.options["table"] = "data-table"

--- a/runestone/codelens/visualizer.py
+++ b/runestone/codelens/visualizer.py
@@ -31,7 +31,7 @@ def setup(app):
 
     app.add_config_value("codelens_div_class", "alert alert-warning cd_section", "html")
     app.add_config_value("trace_url", "http://tracer.runestone.academy:5000", "html")
-    app.add_node(CodeLensNode, html=(visit_codelens_node, depart_codelens_node))
+    app.add_node(CodeLensNode, html=(visit_codelens_html, depart_codelens_html))
 
 
 #  data-tracefile="pytutor-embed-demo/java.json"
@@ -62,28 +62,26 @@ allTraceData["%(divid)s"] = %(tracedata)s;
 
 
 class CodeLensNode(nodes.General, nodes.Element, RunestoneIdNode):
-    def __init__(self, content, **kwargs):
-        super().__init__(**kwargs)
-        self.runestone_options = content
+    pass
 
 
-def visit_codelens_node(self, node):
+def visit_codelens_html(self, node):
     html = VIS
-    if "caption" not in node.runestone_options:
-        node.runestone_options["caption"] = node.runestone_options["question_label"]
-    if "tracedata" in node.runestone_options:
+    if "caption" not in node["runestone_options"]:
+        node["runestone_options"]["caption"] = node["runestone_options"]["question_label"]
+    if "tracedata" in node["runestone_options"]:
         html += DATA
     else:
         html += "</div>"
-    html = html % node.runestone_options
+    html = html % node["runestone_options"]
 
     self.body.append(html)
     addHTMLToDB(
-        node.runestone_options["divid"], node.runestone_options["basecourse"], html
+        node["runestone_options"]["divid"], node["runestone_options"]["basecourse"], html
     )
 
 
-def depart_codelens_node(self, node):
+def depart_codelens_html(self, node):
     pass
 
 
@@ -227,8 +225,9 @@ config values (conf.py):
                 else:
                     raise ValueError("language not supported")
 
-        cl_node = CodeLensNode(self.options, rawsource=self.block_text)
-        cl_node.source, cl_node.line = self.state_machine.get_source_and_line(
+        cl_node = CodeLensNode()
+        cl_node["runestone_options"] = self.options
+        cl_node["source"], cl_node["line"] = self.state_machine.get_source_and_line(
             self.lineno
         )
         return [cl_node]

--- a/runestone/common/question_number.py
+++ b/runestone/common/question_number.py
@@ -7,7 +7,7 @@
 # ======
 # Third-party
 from docutils import nodes
-
+import pdb
 # Local
 from .runestonedirective import RunestoneIdNode
 from ..server.componentdb import addQNumberToDB
@@ -18,8 +18,9 @@ from ..server.componentdb import addQNumberToDB
 # After the section numbers are available from the TOC tree, determine the section number for each Runestone component with an ID.
 def _insert_qnum(app, doctree, docname):
     toc = app.env.toc_secnumbers.get(docname, {})
-
+    pdb.set_trace()
     # Return the section number tuple for the given ``section_ref`` if it exists, or None if not.
+
     def get_secnum_tuple(section_ref):
         # The Sphinx TOC structure is::
         #
@@ -48,8 +49,9 @@ def _insert_qnum(app, doctree, docname):
             question_number_str = ".".join(map(str, question_number_tuple))
             # Update the database.
             addQNumberToDB(app, node, question_number_str)
-            div_id = node.runestone_options["divid"]
-            node.runestone_options["question_label"] = question_number_str
+            pdb.set_trace()
+            div_id = node["runestone_options"]["divid"]
+            node["runestone_options"]["question_label"] = question_number_str
             # Prepare to number the next question.
             current_question_number += 1
         else:

--- a/runestone/common/question_number.py
+++ b/runestone/common/question_number.py
@@ -18,7 +18,6 @@ from ..server.componentdb import addQNumberToDB
 # After the section numbers are available from the TOC tree, determine the section number for each Runestone component with an ID.
 def _insert_qnum(app, doctree, docname):
     toc = app.env.toc_secnumbers.get(docname, {})
-    pdb.set_trace()
     # Return the section number tuple for the given ``section_ref`` if it exists, or None if not.
 
     def get_secnum_tuple(section_ref):
@@ -49,9 +48,12 @@ def _insert_qnum(app, doctree, docname):
             question_number_str = ".".join(map(str, question_number_tuple))
             # Update the database.
             addQNumberToDB(app, node, question_number_str)
-            pdb.set_trace()
-            div_id = node["runestone_options"]["divid"]
-            node["runestone_options"]["question_label"] = question_number_str
+            try:
+                div_id = node["runestone_options"]["divid"]
+                node["runestone_options"]["question_label"] = question_number_str
+            except:
+                div_id = node.runestone_options["divid"]
+                node.runestone_options["question_label"] = question_number_str
             # Prepare to number the next question.
             current_question_number += 1
         else:

--- a/runestone/datafile/__init__.py
+++ b/runestone/datafile/__init__.py
@@ -32,7 +32,7 @@ from runestone.common.runestonedirective import (
 def setup(app):
     app.add_directive("datafile", DataFile)
 
-    app.add_node(DataFileNode, html=(visit_df_node, depart_df_node))
+    app.add_node(DataFileNode, html=(visit_df_html, depart_df_html))
 
     app.connect("doctree-resolved", process_datafile_nodes)
     app.connect("env-purge-doc", purge_datafiles)
@@ -53,25 +53,19 @@ IMG_TEMPLATE = """
 
 
 class DataFileNode(nodes.General, nodes.Element, RunestoneIdNode):
-    def __init__(self, content, **kwargs):
-        """
-        Arguments:
-        - `self`:
-        - `content`:
-        """
-        super(DataFileNode, self).__init__(**kwargs)
-        self.runestone_options = content
-
+    pass
 
 # self for these functions is an instance of the writer class.  For example
 # in html, self is sphinx.writers.html.SmartyPantsHTMLTranslator
 # The node that is passed as a parameter is an instance of our node class.
-def visit_df_node(self, node):
-    if "image" in node.runestone_options:
+
+
+def visit_df_html(self, node):
+    if "image" in node["runestone_options"]:
         res = IMG_TEMPLATE
     else:
         res = TEMPLATE
-    res = res % node.runestone_options
+    res = res % node["runestone_options"]
 
     res = res.replace(
         "u'", "'"
@@ -79,9 +73,9 @@ def visit_df_node(self, node):
     self.body.append(res)
 
 
-def depart_df_node(self, node):
+def depart_df_html(self, node):
     """ This is called at the start of processing an datafile node.  If datafile had recursive nodes
-        etc and did not want to do all of the processing in visit_ac_node any finishing touches could be
+        etc and did not want to do all of the processing in visit_ac_html any finishing touches could be
         added here.
     """
     pass
@@ -210,9 +204,10 @@ class DataFile(RunestoneIdDirective):
                 "This should only affect the grading interface. Everything else should be fine."
             )
 
-        data_file_node = DataFileNode(self.options, rawsource=self.block_text)
+        data_file_node = DataFileNode()
+        data_file_node["runestone_options"] = self.options
         (
-            data_file_node.source,
-            data_file_node.line,
+            data_file_node["source"],
+            data_file_node["line"],
         ) = self.state_machine.get_source_and_line(self.lineno)
         return [data_file_node]

--- a/runestone/disqus/disqus.py
+++ b/runestone/disqus/disqus.py
@@ -68,27 +68,25 @@ DISQUS_LINK = """
 def setup(app):
     app.add_directive("disqus", DisqusDirective)
 
-    app.add_node(DisqusNode, html=(visit_disqus_node, depart_disqus_node))
+    app.add_node(DisqusNode, html=(visit_disqus_html, depart_disqus_html))
     app.connect("doctree-resolved", process_disqus_nodes)
     app.connect("env-purge-doc", purge_disqus_nodes)
 
 
 class DisqusNode(nodes.General, nodes.Element, RunestoneNode):
-    def __init__(self, content, **kwargs):
-        super(DisqusNode, self).__init__(**kwargs)
-        self.disqus_components = content
+    pass
 
 
-def visit_disqus_node(self, node):
+def visit_disqus_html(self, node):
     res = DISQUS_BOX
     res += DISQUS_LINK
 
-    res = res % node.disqus_components
+    res = res % node["runestone_options"]
 
     self.body.append(res)
 
 
-def depart_disqus_node(self, node):
+def depart_disqus_html(self, node):
     pass
 
 
@@ -123,8 +121,9 @@ class DisqusDirective(RunestoneDirective):
         :return:
         """
 
-        disqus_node = DisqusNode(self.options, rawsource=self.block_text)
-        disqus_node.source, disqus_node.line = self.state_machine.get_source_and_line(
+        disqus_node = DisqusNode()
+        disqus_node["runestone_options"] = self.options
+        disqus_node["source"], disqus_node["line"] = self.state_machine.get_source_and_line(
             self.lineno
         )
         return [disqus_node]

--- a/runestone/fitb/test/test_fitb.py
+++ b/runestone/fitb/test/test_fitb.py
@@ -11,11 +11,13 @@ def test_1(selenium_module_fixture):
         (
             38,
             'Content block expected for the "fillintheblank" directive; none found.',
+            "ERROR"
         ),
-        (50, "Not enough feedback for the number of blanks supplied."),
+        (37, "Not enough feedback for the number of blanks supplied.", "WARNING"),
     )
-    for error_line, error_string in directive_level_errors:
-        assert ":{}: WARNING: {}".format(error_line, error_string) in mf.build_stderr_data
+    for error_line, error_string, mtype in directive_level_errors:
+        assert ":{}: {}: {}".format(
+            error_line, mtype, error_string) in mf.build_stderr_data
 
     # Check for the following error inside the directive.
     inside_directive_errors = (
@@ -31,12 +33,13 @@ def test_1(selenium_module_fixture):
         ),
     )
     for error_line, error_string in inside_directive_errors:
-        assert ": WARNING: On line {}, {}".format(error_line, error_string) in mf.build_stderr_data
+        assert ": ERROR: On line {}, {}".format(
+            error_line, error_string) in mf.build_stderr_data
 
     assert "WARNING: while setting up extension runestone.lp: role 'docname' is already registered, it will be overridden" in mf.build_stderr_data
 
     # Make sure we saw all errors.
-    assert len(directive_level_errors) + len(inside_directive_errors) + 1 == mf.build_stderr_data.count("WARNING")
+    assert len(inside_directive_errors) + 1 == mf.build_stderr_data.count("ERROR")
 
 
 # Check that numbering works correctly.
@@ -85,7 +88,8 @@ def test_fitb1(selenium_utils_get):
     find_blank(fitb, 1)
     click_checkme(fitb)
     # Get desired response from .i18n file loaded based on language attribute in the HTML tag initially set in conf.py
-    msg_no_answer = selenium_utils_get.driver.execute_script("return $.i18n('msg_no_answer')")
+    msg_no_answer = selenium_utils_get.driver.execute_script(
+        "return $.i18n('msg_no_answer')")
     check_feedback(selenium_utils_get, fitb, msg_no_answer)
 
 
@@ -97,7 +101,8 @@ def test_fitb2(selenium_utils_get):
     click_checkme(fitb)
     check_feedback(selenium_utils_get, fitb, "Correct")
     # Get desired response from .i18n file loaded based on language attribute in the HTML tag initially set in conf.py
-    msg_no_answer = selenium_utils_get.driver.execute_script("return $.i18n('msg_no_answer')")
+    msg_no_answer = selenium_utils_get.driver.execute_script(
+        "return $.i18n('msg_no_answer')")
     check_feedback(selenium_utils_get, fitb, msg_no_answer)
 
 

--- a/runestone/lp/inlinesyntaxhighlight.py
+++ b/runestone/lp/inlinesyntaxhighlight.py
@@ -37,17 +37,17 @@ def html_visit_literal(self, node):
     if (
         # This is a literal...
         (
-            node.rawsource.startswith("``")
-            and
+            node["rawsource"].startswith("``")
+
             # ...that's not inside a ``:file:``
-            "role" not in node.attributes
-            and
+            and "role" not in node["attributes"]
+
             # ...and we should highlight literals, OR
-            env.config.inline_highlight_literals
+            and env.config.inline_highlight_literals
         )
-        or
+
         # this is a code block, highlight.
-        ("code" in node["classes"])
+        or ("code" in node["classes"])
     ):
 
         if env.config.inline_highlight_respect_highlight:
@@ -55,18 +55,18 @@ def html_visit_literal(self, node):
         else:
             lang = None
 
-        highlight_args = node.get("highlight_args", {})
+        highlight_args = node["get"]("highlight_args", {})
 
-        if node.has_key("language"):
+        if node["has_key"]("language"):
             # code-block directives
             lang = node["language"]
             highlight_args["force"] = True
 
         def warner(msg, **kwargs):
-            self.builder.warn(self.builder.current_docname, msg, node.line, **kwargs)
+            self.builder.warn(self.builder.current_docname, msg, node["line"], **kwargs)
 
         highlighted = self.highlighter.highlight_block(
-            node.astext(), lang, warn=warner, **highlight_args
+            node["astext"](), lang, warn=warner, **highlight_args
         )
 
         # highlighted comes as <div class="highlighted"><pre>...</pre></div>

--- a/runestone/mchoice/assess.py
+++ b/runestone/mchoice/assess.py
@@ -31,16 +31,16 @@ def setup(app):
 
     app.add_config_value("mchoice_div_class", "runestone alert alert-warning", "html")
 
-    app.add_node(MChoiceNode, html=(visit_mc_node, depart_mc_node),
+    app.add_node(MChoiceNode, html=(visit_mc_html, depart_mc_html),
                  xml=(visit_mc_xml, depart_mc_xml))
 
     app.add_node(
-        AnswersBulletList, html=(visit_answers_bullet_node, depart_answers_bullet_node)
+        AnswersBulletList, html=(visit_answers_bullet_html, depart_answers_bullet_html)
     )
     app.add_node(AnswerListItem, html=(visit_answer_list_item, depart_answer_list_item))
     app.add_node(
         FeedbackBulletList,
-        html=(visit_feedback_bullet_node, depart_feedback_bullet_node),
+        html=(visit_feedback_bullet_html, depart_feedback_bullet_html),
     )
     app.add_node(
         FeedbackListItem, html=(visit_feedback_list_item, depart_feedback_list_item)

--- a/runestone/mchoice/assess.py
+++ b/runestone/mchoice/assess.py
@@ -21,7 +21,6 @@ from runestone.common.runestonedirective import RunestoneDirective, RunestoneIdD
 from .multiplechoice import *
 
 
-
 def setup(app):
     app.add_directive("mchoice", MChoice)
     app.add_directive("mchoicemf", MChoiceMF)
@@ -32,7 +31,9 @@ def setup(app):
 
     app.add_config_value("mchoice_div_class", "runestone alert alert-warning", "html")
 
-    app.add_node(MChoiceNode, html=(visit_mc_node, depart_mc_node))
+    app.add_node(MChoiceNode, html=(visit_mc_node, depart_mc_node),
+                 xml=(visit_mc_xml, depart_mc_xml))
+
     app.add_node(
         AnswersBulletList, html=(visit_answers_bullet_node, depart_answers_bullet_node)
     )

--- a/runestone/mchoice/multiplechoice.py
+++ b/runestone/mchoice/multiplechoice.py
@@ -35,7 +35,7 @@ class MChoiceNode(nodes.General, nodes.Element, RunestoneIdNode):
     pass
 
 
-def visit_mc_common(self, node, node_type):
+def visit_mc_common(self, node):
 
     res = ""
     if "random" in node["runestone_options"]:
@@ -81,7 +81,7 @@ def depart_mc_common(self, node):
 
 def visit_mc_xml(self, node):
 
-    res = visit_mc_common(self, node, "xml")
+    res = visit_mc_common(self, node)
     self.output.append(res)
 
 

--- a/runestone/mchoice/multiplechoice.py
+++ b/runestone/mchoice/multiplechoice.py
@@ -33,22 +33,10 @@ from runestone.server.componentdb import (
 
 class MChoiceNode(nodes.General, nodes.Element, RunestoneIdNode):
     pass
-    # def __init__(self, content, **kwargs):
-    #     """
-
-    #     Arguments:
-    #     - `self`:
-    #     - `content`:
-    #     """
-
-    # super(MChoiceNode, self).__init__(**kwargs)
-    # pdb.set_trace()
-    # if type(content) == str:
-    #     self.runestone_options = self.attributes['opts']
-    # else:
-    #     self.runestone_options = content
 
 
+# TODO: refactor the common parts of visit_mc_xml and visit_mc_node -- copy/paste ok for
+#       proof of concept but not long term.
 def visit_mc_xml(self, node):
 
     res = ""

--- a/runestone/mchoice/multiplechoice.py
+++ b/runestone/mchoice/multiplechoice.py
@@ -231,7 +231,6 @@ class MChoice(Assessment):
         mcNode["template_start"] = TEMPLATE_START
         mcNode["template_option"] = OPTION
         mcNode["template_end"] = TEMPLATE_END
-        pdb.set_trace()
         # For MChoice its better to insert the qnum into the content before further processing.
         self.updateContent()
 
@@ -374,21 +373,21 @@ def depart_answers_bullet_html(self, node):
 # Write out the special attributes needed by the ``<li>`` tag.
 def visit_answer_list_item(self, node):
     # See the structure_.
-    mcNode = node.parent.parent
+    mc_node = node.parent.parent
 
     # _`label`: Turn the index of this item in the answer_bullet_list (see structure_) into a letter.
     label = chr(node.parent.index(node) + ord("a"))
     # Update dict for formatting the HTML.
-    mcnode["runestone_options"]["alabel"] = label
-    if label in mcnode["runestone_options"]["correct"]:
-        mcnode["runestone_options"]["is_correct"] = "data-correct"
+    mc_node["runestone_options"]["alabel"] = label
+    if label in mc_node["runestone_options"]["correct"]:
+        mc_node["runestone_options"]["is_correct"] = "data-correct"
     else:
-        mcnode["runestone_options"]["is_correct"] = ""
+        mc_node["runestone_options"]["is_correct"] = ""
 
     # Format the HTML.
     self.body.append(
         '<li data-component="answer" %(is_correct)s id="%(divid)s_opt_%(alabel)s">'
-        % mcnode["runestone_options"]
+        % mc_node["runestone_options"]
     )
 
 
@@ -410,12 +409,12 @@ def depart_feedback_bullet_html(self, node):
 def visit_feedback_list_item(self, node):
     # See label_ and structure_.
     answer_list_item = node.parent.parent
-    mcNode = answer_list_item.parent.parent
+    mc_node = answer_list_item.parent.parent
     label = chr(answer_list_item.parent.index(answer_list_item) + ord("a"))
-    mcnode["runestone_options"]["alabel"] = label
+    mc_node["runestone_options"]["alabel"] = label
     self.body.append(
         '</li><li data-component="feedback" id="%(divid)s_opt_%(alabel)s">\n'
-        % mcnode["runestone_options"]
+        % mc_node["runestone_options"]
     )
 
 

--- a/runestone/mchoice/test/test_assess.py
+++ b/runestone/mchoice/test/test_assess.py
@@ -27,7 +27,7 @@ def test_1(selenium_module_fixture):
         (102, "No correct answer specified."),
     )
     for error_line, error_string in directive_level_errors:
-        assert ":{}: WARNING: {}".format(error_line, error_string) in mf.build_stderr_data
+        assert ":{}: ERROR: {}".format(error_line, error_string) in mf.build_stderr_data
 
     # Check for the following error inside the directive.
     inside_directive_lines = (
@@ -39,14 +39,15 @@ def test_1(selenium_module_fixture):
         95,
     )
     for error_line in inside_directive_lines:
-        assert ": WARNING: On line {}, a single-item list must be nested under each answer.".format(
+        assert ": ERROR: On line {}, a single-item list must be nested under each answer.".format(
             error_line
         ) in mf.build_stderr_data
 
     assert "WARNING: while setting up extension runestone.lp: role 'docname' is already registered, it will be overridden" in mf.build_stderr_data
 
     # Make sure we saw all errors.
-    assert (len(directive_level_errors) + len(inside_directive_lines) + 1) == mf.build_stderr_data.count("WARNING")
+    assert (len(directive_level_errors) + len(inside_directive_lines)
+            ) == mf.build_stderr_data.count("ERROR")
 
 
 # Run-time checks

--- a/runestone/question/question.py
+++ b/runestone/question/question.py
@@ -24,36 +24,34 @@ __author__ = "bmiller"
 def setup(app):
     app.add_directive("question", QuestionDirective)
 
-    app.add_node(QuestionNode, html=(visit_question_node, depart_question_node))
+    app.add_node(QuestionNode, html=(visit_question_html, depart_question_html))
 
 
 class QuestionNode(nodes.General, nodes.Element, RunestoneIdNode):
-    def __init__(self, content, **kwargs):
-        super(QuestionNode, self).__init__(**kwargs)
-        self.runestone_options = content
+    pass
 
 
-def visit_question_node(self, node):
+def visit_question_html(self, node):
     # Set options and format templates accordingly
     env = node.document.settings.env
     if not hasattr(env, "questioncounter"):
         env.questioncounter = 0
 
-    if "number" in node.runestone_options:
-        env.questioncounter = int(node.runestone_options["number"])
+    if "number" in node["runestone_options"]:
+        env.questioncounter = int(node["runestone_options"]["number"])
     else:
         env.questioncounter += 1
 
-    node.runestone_options["number"] = "start={}".format(env.questioncounter)
+    node["runestone_options"]["number"] = "start={}".format(env.questioncounter)
 
-    res = TEMPLATE_START % node.runestone_options
+    res = TEMPLATE_START % node["runestone_options"]
     self.body.append(res)
 
 
-def depart_question_node(self, node):
+def depart_question_html(self, node):
     # Set options and format templates accordingly
-    res = TEMPLATE_END % node.runestone_options
-    delimiter = "_start__{}_".format(node.runestone_options["divid"])
+    res = TEMPLATE_END % node["runestone_options"]
+    delimiter = "_start__{}_".format(node["runestone_options"]["divid"])
 
     self.body.append(res)
 
@@ -92,8 +90,9 @@ class QuestionDirective(RunestoneIdDirective):
 
         self.options["name"] = self.arguments[0].strip()
 
-        question_node = QuestionNode(self.options, rawsource=self.block_text)
-        question_node.source, question_node.line = self.state_machine.get_source_and_line(
+        question_node = QuestionNode()
+        question_node["runestone_options"] = self.options
+        question_node["source"], question_node["line"] = self.state_machine.get_source_and_line(
             self.lineno
         )
         self.add_name(question_node)

--- a/runestone/quizly/quizly.py
+++ b/runestone/quizly/quizly.py
@@ -19,22 +19,23 @@
 
 # Note: An import entry for quizly must be included in runestone/__init__.py
 
-# Note: The content files for the quizly component must stored in the 
+# Note: The content files for the quizly component must stored in the
 # course's _static folder. Download the following file and unzip it in _static:
 #  https://github.com/ram8647/quizly/blob/35ee7c945e6f240450f46f41ad9c80735215b5e0/quizly-runestone.zip
 #
 
+import shutil
+import os
+from pathlib import Path
+from runestone.server.componentdb import addQuestionToDB, addHTMLToDB
+from runestone.common import RunestoneIdDirective, RunestoneIdNode
+from docutils import nodes
 __author__ = "rmorelli"
 
 # Debug flags
 DEBUG = False
 VERBOSE = False
 
-import os, shutil
-from docutils import nodes
-from runestone.common import RunestoneIdDirective, RunestoneIdNode
-from runestone.server.componentdb import addQuestionToDB, addHTMLToDB
-from pathlib import Path
 
 # Template that will load index.html?quizname=the-quiz-name into an <iframe>
 # NOTE: Hardcoding the container class.  Temporarily??
@@ -48,57 +49,53 @@ QUIZLY_TEMPLATE = """
        """
 
 # Define the quizly directive
+
+
 def setup(app):
     app.add_directive("quizly", Quizly)
-    app.add_node(QuizlyNode, html=(visit_quizly_node, depart_quizly_node))
+    app.add_node(QuizlyNode, html=(visit_quizly_html, depart_quizly_html))
 
 # The only content needed from quizly.py is the quizname
+
+
 class QuizlyNode(nodes.General, nodes.Element, RunestoneIdNode):
-    def __init__(self, content, **kwargs):
-        """
-        Arguments:
-        - `self`:
-        - `content`:
-        """
-        super(QuizlyNode, self).__init__(**kwargs)
-        self.runestone_options = content
-        print('DEBUG: QuizlyNode content = ' + str(content)) if DEBUG else None
-        self.quizname = str(content['controls'][0])
-        self.quizname = str.strip(self.quizname[10:])
-        self.template = QUIZLY_TEMPLATE.replace('###', self.quizname)
-        print('DEBUG: QuizlyNode self.quizname = ' + self.quizname) if DEBUG else None
+    pass
+
 
 # self for these functions is an instance of the writer class.  For example
 # in html, self is sphinx.writers.html.SmartyPantsHTMLTranslator
 # The node that is passed as a parameter is an instance of our node class.
-def visit_quizly_node(self, node):
 
-    node.delimiter = "_start__{}_".format(node.runestone_options["divid"])
-    self.body.append(node.delimiter)
 
-    print('DEBUG: visit_quizly_node quizname = ' + node.quizname) if DEBUG else None
-    print('DEBUG: visit_quizly_node template = ' + node.template) if DEBUG else None
-    print('DEBUG: visit_quizly_node options = ' + str(node.runestone_options)) if DEBUG else None
+def visit_quizly_html(self, node):
 
-    res = node.template % (node.runestone_options)
-    print('DEBUG: visit_quizly_node res = ' + res) if DEBUG else None
+    node["delimiter"] = "_start__{}_".format(node["runestone_options"]["divid"])
+    self.body.append(node["delimiter"])
+
+    print('DEBUG: visit_quizly_html quizname = ' + node["quizname"]) if DEBUG else None
+    print('DEBUG: visit_quizly_html template = ' + node["template"]) if DEBUG else None
+    print('DEBUG: visit_quizly_html options = '
+          + str(node["runestone_options"])) if DEBUG else None
+
+    res = node["template"] % (node["runestone_options"])
+    print('DEBUG: visit_quizly_html res = ' + res) if DEBUG else None
     self.body.append(res)
 
 
-def depart_quizly_node(self, node):
+def depart_quizly_html(self, node):
     """ This is called at the start of processing an activecode node.  If activecode had recursive nodes
-        etc and did not want to do all of the processing in visit_ac_node any finishing touches could be
+        etc and did not want to do all of the processing in visit_ac_html any finishing touches could be
         added here.
     """
-    print('DEBUG: depart_quizly_node') if DEBUG else None
-    bc = node.runestone_options["basecourse"]
+    print('DEBUG: depart_quizly_html') if DEBUG else None
+    bc = node["runestone_options"]["basecourse"]
     addHTMLToDB(
-        node.runestone_options["divid"],
+        node["runestone_options"]["divid"],
         bc,
-        "".join(self.body[self.body.index(node.delimiter) + 1 :])
-        .replace("../_static",f"/runestone/books/published/{bc}/_static"),
+        "".join(self.body[self.body.index(node["delimiter"]) + 1 :])
+        .replace("../_static", f"/runestone/books/published/{bc}/_static"),
     )
-    self.body.remove(node.delimiter)
+    self.body.remove(node["delimiter"])
 
 
 def process_activcode_nodes(app, env, docname):
@@ -137,11 +134,15 @@ class Quizly(RunestoneIdDirective):
         if self.content:
             self.options["controls"] = self.content[:plstart]
 
-        quizly_node = QuizlyNode(self.options, rawsource=self.block_text)
-        quizly_node.source, quizly_node.line = self.state_machine.get_source_and_line(
+        quizly_node = QuizlyNode()
+        quizly_node["quizname"] = str(self.options['controls'][0])
+        quizly_node["quizname"] = str.strip(quizly_node["quizname"][10:])
+        quizly_node["template"] = QUIZLY_TEMPLATE.replace(
+            '###', quizly_node["quizname"])
+
+        quizly_node["source"], quizly_node["line"] = self.state_machine.get_source_and_line(
             self.lineno
         )
         print('DEBUG: run() self.content = ' + str(self.content)) if DEBUG else None
         print('DEBUG: run() quizly_node = ' + str(quizly_node)) if DEBUG else None
         return [quizly_node]
-

--- a/runestone/reveal/reveal.py
+++ b/runestone/reveal/reveal.py
@@ -24,47 +24,45 @@ from runestone.common.runestonedirective import RunestoneDirective, RunestoneNod
 def setup(app):
     app.add_directive("reveal", RevealDirective)
 
-    app.add_node(RevealNode, html=(visit_reveal_node, depart_reveal_node))
+    app.add_node(RevealNode, html=(visit_reveal_html, depart_reveal_html))
 
 
 class RevealNode(nodes.General, nodes.Element, RunestoneNode):
-    def __init__(self, content, **kwargs):
-        super(RevealNode, self).__init__(**kwargs)
-        self.runestone_options = content
+    pass
 
 
-def visit_reveal_node(self, node):
+def visit_reveal_html(self, node):
     # Set options and format templates accordingly
 
-    if "modal" in node.runestone_options:
-        node.runestone_options["modal"] = "data-modal"
+    if "modal" in node["runestone_options"]:
+        node["runestone_options"]["modal"] = "data-modal"
     else:
-        node.runestone_options["modal"] = ""
+        node["runestone_options"]["modal"] = ""
 
-    if "modaltitle" in node.runestone_options:
-        temp = node.runestone_options["modaltitle"]
-        node.runestone_options["modaltitle"] = """data-title=""" + '"' + temp + '"'
+    if "modaltitle" in node["runestone_options"]:
+        temp = node["runestone_options"]["modaltitle"]
+        node["runestone_options"]["modaltitle"] = """data-title=""" + '"' + temp + '"'
     else:
-        node.runestone_options["modaltitle"] = ""
+        node["runestone_options"]["modaltitle"] = ""
 
     if (
-        node.runestone_options["instructoronly"]
-        and node.runestone_options["is_dynamic"]
+        node["runestone_options"]["instructoronly"]
+        and node["runestone_options"]["is_dynamic"]
     ):
         res = DYNAMIC_PREFIX
     else:
         res = ""
 
-    res += TEMPLATE_START % node.runestone_options
+    res += TEMPLATE_START % node["runestone_options"]
     self.body.append(res)
 
 
-def depart_reveal_node(self, node):
+def depart_reveal_html(self, node):
     # Set options and format templates accordingly
-    res = TEMPLATE_END % node.runestone_options
+    res = TEMPLATE_END % node["runestone_options"]
     if (
-        node.runestone_options["instructoronly"]
-        and node.runestone_options["is_dynamic"]
+        node["runestone_options"]["instructoronly"]
+        and node["runestone_options"]["is_dynamic"]
     ):
         res += DYNAMIC_SUFFIX
 
@@ -158,8 +156,9 @@ class RevealDirective(RunestoneDirective):
         is_dynamic = env.config.html_context.get("dynamic_pages", False)
         self.options["is_dynamic"] = is_dynamic
 
-        reveal_node = RevealNode(self.options, rawsource=self.block_text)
-        reveal_node.source, reveal_node.line = self.state_machine.get_source_and_line(
+        reveal_node = RevealNode()
+        reveal_node["runestone_options"] = self.options
+        reveal_node["source"], reveal_node["line"] = self.state_machine.get_source_and_line(
             self.lineno
         )
 

--- a/runestone/server/componentdb.py
+++ b/runestone/server/componentdb.py
@@ -420,7 +420,7 @@ def addQNumberToDB(app, node, qnumber):
         questions.update()
         .where(
             and_(
-                questions.c.name == node.runestone_options["divid"],
+                questions.c.name == node["runestone_options"]["divid"],
                 questions.c.base_course == basecourse,
             )
         )

--- a/runestone/shortanswer/shortanswer.py
+++ b/runestone/shortanswer/shortanswer.py
@@ -29,7 +29,7 @@ from runestone.common.runestonedirective import RunestoneDirective, RunestoneIdN
 
 def setup(app):
     app.add_directive("shortanswer", JournalDirective)
-    app.add_node(JournalNode, html=(visit_journal_node, depart_journal_node))
+    app.add_node(JournalNode, html=(visit_journal_html, depart_journal_html))
     app.add_config_value("shortanswer_div_class", "journal alert alert-warning", "html")
     app.add_config_value(
         "shortanswer_optional_div_class", "journal alert alert-success", "html"
@@ -48,38 +48,36 @@ TEXT_END = """
 
 
 class JournalNode(nodes.General, nodes.Element, RunestoneIdNode):
-    def __init__(self, options, **kwargs):
-        super(JournalNode, self).__init__(**kwargs)
-        self.runestone_options = options
+    pass
 
 
-def visit_journal_node(self, node):
-    div_id = node.runestone_options["divid"]
-    components = dict(node.runestone_options)
+def visit_journal_html(self, node):
+    div_id = node["runestone_options"]["divid"]
+    components = dict(node["runestone_options"])
     components.update({"divid": div_id})
 
-    node.delimiter = "_start__{}_".format(node.runestone_options["divid"])
-    self.body.append(node.delimiter)
+    node["delimiter"] = "_start__{}_".format(node["runestone_options"]["divid"])
+    self.body.append(node["delimiter"])
 
     res = TEXT_START % components
 
     self.body.append(res)
 
 
-def depart_journal_node(self, node):
+def depart_journal_html(self, node):
 
-    components = dict(node.runestone_options)
+    components = dict(node["runestone_options"])
 
     res = TEXT_END % components
     self.body.append(res)
 
     addHTMLToDB(
-        node.runestone_options["divid"],
+        node["runestone_options"]["divid"],
         components["basecourse"],
-        "".join(self.body[self.body.index(node.delimiter) + 1 :]),
+        "".join(self.body[self.body.index(node["delimiter"]) + 1 :]),
     )
 
-    self.body.remove(node.delimiter)
+    self.body.remove(node["delimiter"])
 
 
 class JournalDirective(Assessment):
@@ -112,8 +110,9 @@ config values (conf.py):
 
         self.options["mathjax"] = "data-mathjax" if "mathjax" in self.options else ""
 
-        journal_node = JournalNode(self.options, rawsource=self.block_text)
-        journal_node.source, journal_node.line = self.state_machine.get_source_and_line(
+        journal_node = JournalNode()
+        journal_node["runestone_options"] = self.options
+        journal_node["source"], journal_node["line"] = self.state_machine.get_source_and_line(
             self.lineno
         )
 

--- a/runestone/showeval/showeval.py
+++ b/runestone/showeval/showeval.py
@@ -27,25 +27,23 @@ def setup(app):
     app.add_config_value(
         "showeval_div_class", "runestone explainer alert alert-warning", "html"
     )
-    app.add_node(ShowEvalNode, html=(visit_showeval_node, depart_showeval_node))
+    app.add_node(ShowEvalNode, html=(visit_showeval_html, depart_showeval_html))
 
 
 # Create visitors, so we can generate HTML after the doctree is resolve (where the question label is determined).
 class ShowEvalNode(nodes.General, nodes.Element, RunestoneIdNode):
-    def __init__(self, content, **kwargs):
-        super().__init__(**kwargs)
-        self.runestone_options = content
+    pass
 
 
-def visit_showeval_node(self, node):
-    html = CODE % node.runestone_options
+def visit_showeval_html(self, node):
+    html = CODE % node["runestone_options"]
     self.body.append(html)
     addHTMLToDB(
-        node.runestone_options["divid"], node.runestone_options["basecourse"], html
+        node["runestone_options"]["divid"], node["runestone_options"]["basecourse"], html
     )
 
 
-def depart_showeval_node(self, node):
+def depart_showeval_html(self, node):
     pass
 
 
@@ -144,5 +142,6 @@ config values (conf.py):
                 step = True
             else:
                 self.options["preReqLines"] += line + "<br />\n"
-
-        return [ShowEvalNode(self.options, rawsource=self.block_text)]
+        se_node = ShowEvalNode()
+        se_node["runestone_options"] = self.options
+        return [se_node]

--- a/runestone/spreadsheet/spreadsheet.py
+++ b/runestone/spreadsheet/spreadsheet.py
@@ -34,10 +34,12 @@ from runestone.server.componentdb import addQuestionToDB, addHTMLToDB
 # setup is called when extensions are loaded. This registers the new directive and
 # logs any js or css files that should be loaded for this extension.
 #
+
+
 def setup(app):
     app.add_directive("spreadsheet", SpreadSheet)
 
-    app.add_node(SpreadSheetNode, html=(visit_ss_node, depart_ss_node))
+    app.add_node(SpreadSheetNode, html=(visit_ss_html, depart_ss_html))
 
 
 # When the directive is process we will create nodes in the document tree to account
@@ -45,16 +47,7 @@ def setup(app):
 # textbooks as HTML one could, render the nodes as LaTex or many other languages.
 #
 class SpreadSheetNode(nodes.General, nodes.Element, RunestoneIdNode):
-    def __init__(self, content, **kwargs):
-        """
-
-        Arguments:
-        - `self`:
-        - `content`:
-        """
-        super(SpreadSheetNode, self).__init__(**kwargs)
-        self.runestone_options = content
-
+    pass
 
 #
 # The spreadsheet class implements the directive.
@@ -62,6 +55,8 @@ class SpreadSheetNode(nodes.General, nodes.Element, RunestoneIdNode):
 # This allows us to handle any arguments, and then create a node or nodes to insert into the
 # document tree to be rendered when the tree is written.
 #
+
+
 class SpreadSheet(RunestoneIdDirective):
     """
     .. spreadsheet:: uniqueid
@@ -140,8 +135,10 @@ class SpreadSheet(RunestoneIdDirective):
                 ",".join([x.strip() for x in self.options["colwidths"].split(",")])
             )
 
-        ssnode = SpreadSheetNode(self.options, rawsource=self.block_text)
-        ssnode.source, ssnode.line = self.state_machine.get_source_and_line(self.lineno)
+        ssnode = SpreadSheetNode()
+        ssnode["runestone_options"] = self.options
+        ssnode["source"], ssnode["line"] = self.state_machine.get_source_and_line(
+            self.lineno)
         self.add_name(ssnode)  # make this divid available as a target for :ref:
 
         return [ssnode]
@@ -222,10 +219,10 @@ TEMPLATE = """
 """
 
 
-def visit_ss_node(self, node):
-    res = TEMPLATE.format(**node.runestone_options)
+def visit_ss_html(self, node):
+    res = TEMPLATE.format(**node["runestone_options"])
     self.body.append(res)
 
 
-def depart_ss_node(self, node):
+def depart_ss_html(self, node):
     pass

--- a/runestone/timed/timedassessment.py
+++ b/runestone/timed/timedassessment.py
@@ -42,64 +42,64 @@ from runestone.server.componentdb import addAssignmentToDB
 # Timed Assessment Implementation
 # -------------------------------
 # Everydirective uses setup to add itself to the applications and add any nodes
+
+
 def setup(app):
     app.add_directive("timed", TimedDirective)
-    app.add_node(TimedNode, html=(visit_timed_node, depart_timed_node))
+    app.add_node(TimedNode, html=(visit_timed_html, depart_timed_html))
 
 
 class TimedNode(nodes.General, nodes.Element, RunestoneIdNode):
-    def __init__(self, content, **kwargs):
-        super(TimedNode, self).__init__(**kwargs)
-        self.runestone_options = content
+    pass
 
 
-def visit_timed_node(self, node):
+def visit_timed_html(self, node):
     # Set options and format templates accordingly
 
-    if "timelimit" not in node.runestone_options:
-        node.runestone_options["timelimit"] = ""
+    if "timelimit" not in node["runestone_options"]:
+        node["runestone_options"]["timelimit"] = ""
     else:
-        node.runestone_options["timelimit"] = "data-time=" + str(
-            node.runestone_options["timelimit"]
+        node["runestone_options"]["timelimit"] = "data-time=" + str(
+            node["runestone_options"]["timelimit"]
         )
 
-    if "noresult" in node.runestone_options:
-        node.runestone_options["noresult"] = "data-no-result"
+    if "noresult" in node["runestone_options"]:
+        node["runestone_options"]["noresult"] = "data-no-result"
     else:
-        node.runestone_options["noresult"] = ""
+        node["runestone_options"]["noresult"] = ""
 
-    if "timedfeedback" in node.runestone_options:
-        node.runestone_options["timedfeedback"] = "data-timedfeedback=true"
+    if "timedfeedback" in node["runestone_options"]:
+        node["runestone_options"]["timedfeedback"] = "data-timedfeedback=true"
     else:
-        node.runestone_options["timedfeedback"] = ""
+        node["runestone_options"]["timedfeedback"] = ""
 
-    if "notimer" in node.runestone_options:
-        node.runestone_options["notimer"] = "data-no-timer"
+    if "notimer" in node["runestone_options"]:
+        node["runestone_options"]["notimer"] = "data-no-timer"
     else:
-        node.runestone_options["notimer"] = ""
+        node["runestone_options"]["notimer"] = ""
 
-    if "nofeedback" in node.runestone_options:
-        node.runestone_options["nofeedback"] = "data-no-feedback"
+    if "nofeedback" in node["runestone_options"]:
+        node["runestone_options"]["nofeedback"] = "data-no-feedback"
     else:
-        node.runestone_options["nofeedback"] = ""
+        node["runestone_options"]["nofeedback"] = ""
 
-    if "fullwidth" in node.runestone_options:
-        node.runestone_options["fullwidth"] = "data-fullwidth"
+    if "fullwidth" in node["runestone_options"]:
+        node["runestone_options"]["fullwidth"] = "data-fullwidth"
     else:
-        node.runestone_options["fullwidth"] = ""
+        node["runestone_options"]["fullwidth"] = ""
 
-    if "nopause" in node.runestone_options:
-        node.runestone_options["nopause"] = "data-no-pause"
+    if "nopause" in node["runestone_options"]:
+        node["runestone_options"]["nopause"] = "data-no-pause"
     else:
-        node.runestone_options["nopause"] = ""
+        node["runestone_options"]["nopause"] = ""
 
-    res = TEMPLATE_START % node.runestone_options
+    res = TEMPLATE_START % node["runestone_options"]
     self.body.append(res)
 
 
-def depart_timed_node(self, node):
+def depart_timed_html(self, node):
     # Set options and format templates accordingly
-    res = TEMPLATE_END % node.runestone_options
+    res = TEMPLATE_END % node["runestone_options"]
 
     self.body.append(res)
 
@@ -162,8 +162,9 @@ class TimedDirective(RunestoneIdDirective):
         else:
             timelimit = None
 
-        timed_node = TimedNode(self.options, rawsource=self.block_text)
-        timed_node.source, timed_node.line = self.state_machine.get_source_and_line(
+        timed_node = TimedNode()
+        timed_node["runestone_options"] = self.options
+        timed_node["source"], timed_node["line"] = self.state_machine.get_source_and_line(
             self.lineno
         )
         # Use the environment so that any parsed directives will know they

--- a/runestone/video/video.py
+++ b/runestone/video/video.py
@@ -30,7 +30,7 @@ def setup(app):
     app.add_directive("video", Video)
     app.add_directive("youtube", Youtube)
     app.add_directive("vimeo", Vimeo)
-    app.add_node(VideoNode, html=(visit_video_node, depart_video_node))
+    app.add_node(VideoNode, html=(visit_video_html, depart_video_html))
 
 
 CODE = """\
@@ -85,21 +85,18 @@ SOURCE = """<source src="%s" type="video/%s"></source>"""
 
 
 class VideoNode(nodes.General, nodes.Element, RunestoneIdNode):
-    def __init__(self, content, **kwargs):
-        super().__init__(**kwargs)
-        self.runestone_options = content
-        self.template = kwargs["template"]
+    pass
 
 
-def visit_video_node(self, node):
-    html = node.template % node.runestone_options
+def visit_video_html(self, node):
+    html = node["template"] % node["runestone_options"]
     self.body.append(html)
     addHTMLToDB(
-        node.runestone_options["divid"], node.runestone_options["basecourse"], html
+        node["runestone_options"]["divid"], node["runestone_options"]["basecourse"], html
     )
 
 
-def depart_video_node(self, node):
+def depart_video_html(self, node):
     pass
 
 
@@ -235,11 +232,11 @@ class IframeVideo(RunestoneIdDirective):
 
         # res = self.html % self.options
         # addHTMLToDB(self.options["divid"], self.options["basecourse"], res)
-        raw_node = VideoNode(
-            self.options, rawsource=self.block_text, template=self.html
-        )
+        raw_node = VideoNode()
+        raw_node["runestone_options"] = self.options
+        raw_node["template"] = self.html
         # nodes.raw(self.block_text, res, format="html")
-        raw_node.source, raw_node.line = self.state_machine.get_source_and_line(
+        raw_node["source"], raw_node["line"] = self.state_machine.get_source_and_line(
             self.lineno
         )
         return [raw_node]


### PR DESCRIPTION
This is a draft PR, a work in progress to create a second output mode for Runestone books.  Instead of generating the usual html this PR aims to output XML that can be further converted into PreTeXt (PTX).  After conversion the source can be built with the PreTeXt tools into html, epub, braille pdf, etc.   

Why?

1. The goal is for the Runestone project to let go of the authoring side of books and leave that to the PreTeXt project.  A very nice division of labor. That allows us to focus on the components and the server
2. PreTeXt books work on the Runestone Academy platform and will get better over time.  But only if there are books, in PTX that use all of the features!  Its a push-pull relationship
3. To move forward to more fully customizing textbooks requires a more structured authoring language. PTX is already there.
4. If people really want to keep writing books in restructuredText they can... but this also provides a path to other output formats or the eventual move to PTX.

The main challenges of this PR are to get decent looking XML output for our directives.  I'm targeting thinkcspy as it is the oldest in the family, and could use some love.

Unfortunately generating XML has uncovered a few problems with how we coded the HTML generation.

I would welcome early comments on the changes I have made. @bjones1 I am looking in your direction... I would also welcome any help in the "wood chopping" phase of this conversion.  The basic flaw in our implementation is that we did not follow the (undocumented) interface for nodes derived from docutils `nodes.General` and `nodes.Element` that is we should not have a constructor that takes our own parameters and we should not add arbitrary attributes to a derived node.  Instead we should treat a node like a dictionary and add new values to the node that way.
