### PR TITLE
Since the git protocol is in no more use. Line: 67

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Or, if you prefer to live on the development edge, you can check out the very la
 
 ::
 
-    pip install git+git://github.com/RunestoneInteractive/RunestoneComponents.git
+    pip install git+https://github.com/RunestoneInteractive/RunestoneComponents
 
 
 To start a project, create a new folder and then run the following command (installed by pip)  in that new folder ``runestone init``  For example:


### PR DESCRIPTION
Earlier the link to download the project using pip was consisting of "pip install git+git://github.com/RunestoneInteractive/RunestoneComponents.git". But, since the git protocol is not more supported. Hence, I am updating the link for those who want to download the latest development of Runestone on PC using pip for work.

I have checked it. This works perfectly fine.
https://github.blog/2021-09-01-improving-git-protocol-security-github/