### PR TITLE
Fix CI failures caused by a urllib3 version conflict.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,6 +41,8 @@ jobs:
                   # Install as editable so that tests run in cwd, instead of in wherever Python puts system lib. This is important because tests are run on the local (not system lib) files. Therefore, the npm run build produces its files locally, not in system libs; if installed in system libs, then the components won't be able to find these files.
                   pip install -e .
                   if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+                  # Resolve any dependency conflicts in favor of the production versions.
+                  pip install -r requirements.txt
             - name: Tests
               run: |
                 pytest


### PR DESCRIPTION
Fixing CI failures due to urllib3 version disagreements in RunestoneInteractive/rs#37.