### PR TITLE
Fix indentation handling for DAG based Parsons problems

### DIFF
--- a/runestone/parsons/js/dagGrader.js
+++ b/runestone/parsons/js/dagGrader.js
@@ -95,12 +95,19 @@ export default class DAGGrader extends LineBasedGrader {
   checkCorrectIndentation(solutionLines, answerLines) {
       this.indentLeft = [];
       this.indentRight = [];
+
+      let indentationByTag = {};
+      for (let i = 0; i < solutionLines.length; i++) {
+        const line = solutionLines[i];
+        indentationByTag[line.tag] = line.indent;
+      }
+
       let loopLimit = Math.min(solutionLines.length, answerLines.length);
       for (let i = 0; i < loopLimit; i++) {
-          let solutionIndex = answerLines[i].tag;
-          if (answerLines[i].viewIndent() < solutionLines[solutionIndex].indent) {
+          let solutionIndent = indentationByTag[answerLines[i].tag];
+          if (answerLines[i].viewIndent() < solutionIndent) {
               this.indentRight.push(answerLines[i]);
-          } else if (answerLines[i].viewIndent() > solutionLines[solutionIndex].indent) {
+          } else if (answerLines[i].viewIndent() > solutionIndent) {
               this.indentLeft.push(answerLines[i]);
           }
       }

--- a/runestone/parsons/js/dagGrader.js
+++ b/runestone/parsons/js/dagGrader.js
@@ -92,6 +92,24 @@ export default class DAGGrader extends LineBasedGrader {
     return indices;
   }
 
+  checkCorrectIndentation(solutionLines, answerLines) {
+      this.indentLeft = [];
+      this.indentRight = [];
+      let loopLimit = Math.min(solutionLines.length, answerLines.length);
+      for (let i = 0; i < loopLimit; i++) {
+          let solutionIndex = answerLines[i].tag;
+          if (answerLines[i].viewIndent() < solutionLines[solutionIndex].indent) {
+              this.indentRight.push(answerLines[i]);
+          } else if (answerLines[i].viewIndent() > solutionLines[solutionIndex].indent) {
+              this.indentLeft.push(answerLines[i]);
+          }
+      }
+      this.incorrectIndents =
+          this.indentLeft.length + this.indentRight.length;
+
+      return this.incorrectIndents == 0;
+  }
+
   checkCorrectOrdering(solutionLines, answerLines) {
     if (!isDirectedAcyclicGraph(graphToNX(solutionLines))) {
       throw "Dependency between blocks does not form a Directed Acyclic Graph; Problem unsolvable.";

--- a/runestone/parsons/js/lineGrader.js
+++ b/runestone/parsons/js/lineGrader.js
@@ -75,20 +75,10 @@ export default class LineBasedGrader {
         let isCorrectOrder = this.checkCorrectOrdering(solutionLines, answerLines)
 
         // Determine whether blocks are indented correctly
-        this.indentLeft = [];
-        this.indentRight = [];
-        let loopLimit = Math.min(solutionLines.length, answerLines.length);
-        for (i = 0; i < loopLimit; i++) {
-            if (answerLines[i].viewIndent() < solutionLines[i].indent) {
-                this.indentRight.push(answerLines[i]);
-            } else if (answerLines[i].viewIndent() > solutionLines[i].indent) {
-                this.indentLeft.push(answerLines[i]);
-            }
-        }
-        this.incorrectIndents =
-            this.indentLeft.length + this.indentRight.length;
+        let isCorrectIndents = this.checkCorrectIndentation(solutionLines, answerLines);
+
         if (
-            this.incorrectIndents == 0 &&
+            isCorrectIndents &&
             isCorrectOrder &&
             this.correctLength
         ) {
@@ -103,6 +93,23 @@ export default class LineBasedGrader {
         this.graderState = state;
 
         return state;
+    }
+
+    checkCorrectIndentation(solutionLines, answerLines) {
+        this.indentLeft = [];
+        this.indentRight = [];
+        let loopLimit = Math.min(solutionLines.length, answerLines.length);
+        for (let i = 0; i < loopLimit; i++) {
+            if (answerLines[i].viewIndent() < answerLines[i].indent) {
+                this.indentRight.push(answerLines[i]);
+            } else if (answerLines[i].viewIndent() > solutionLines[i].indent) {
+                this.indentLeft.push(answerLines[i]);
+            }
+        }
+        this.incorrectIndents =
+            this.indentLeft.length + this.indentRight.length;
+
+        return this.incorrectIndents == 0;
     }
 
     checkCorrectOrdering(solutionLines, answerLines) {

--- a/runestone/parsons/js/parsons.js
+++ b/runestone/parsons/js/parsons.js
@@ -309,7 +309,12 @@ export default class Parsons extends RunestoneBase {
                     s.replace(/\s+/g, "")
                 ); // remove whitespace in tag and depends list
                 tagIndex = textBlock.indexOf("#tag:");
-                tag = textBlock.substring(tagIndex + 5, tagIndex + 6);
+                tag = textBlock.substring(
+                    tagIndex + 5,
+                    textBlock.indexOf(";", tagIndex + 5)
+                );
+                if (tag == "")
+                    tag = "block-" + i;
                 dependsIndex = textBlock.indexOf(";depends:");
                 let dependsString = textBlock.substring(
                     dependsIndex + 9,

--- a/runestone/parsons/test/_sources/index.rst
+++ b/runestone/parsons/test/_sources/index.rst
@@ -147,3 +147,34 @@ Proof Blocks
   $c'(u) \ne c'(v)$ #tag:7;depends:6,3;
   =====
   $c'$ is a 2-coloring of $H$, so $H$ is 2-colorable. (end of proof) #tag:8;depends:7;
+
+============
+Code DAG
+============
+
+.. parsonsprob:: test_parsons_dag_indent
+   :grader: dag
+
+   Test that indentation works with dag
+
+   .. code-block:: python
+
+      def foo:
+         if True:
+            return 2
+      def bar:
+         return 40
+      print(foo() + bar())
+
+   -----
+   def foo(): #tag:foo;depends:;
+   =====
+      if True: #tag:foo_if; depends:foo;
+   =====
+         return 2 #tag:f1; depends:foo_if;
+   =====
+   def bar(): #tag:bar;depends:;
+   =====
+      return 40 #tag:b1; depends:bar;
+   =====
+   print(foo() + bar()) #tag:asdf; depends: f1,b1;

--- a/runestone/parsons/test/test_parsons.py
+++ b/runestone/parsons/test/test_parsons.py
@@ -10,119 +10,120 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
 
 
 def test_general(selenium_utils_get):
     selenium_utils_get.wait_until_ready("test_parsons_1")
 
     # Source has correct number of blocks and each block has a label
-    source = selenium_utils_get.driver.find_element_by_id("parsons-1-source")
-    answer = selenium_utils_get.driver.find_element_by_id("parsons-1-answer")
-    blocks = source.find_elements_by_class_name("block")
+    source = selenium_utils_get.driver.find_element(By.ID, "parsons-1-source")
+    answer = selenium_utils_get.driver.find_element(By.ID, "parsons-1-answer")
+    blocks = source.find_elements(By.CLASS_NAME, "block")
     assert source
     assert len(blocks) == 5
 
     # check that messages appear correctly
-    checkme = selenium_utils_get.driver.find_element_by_id("parsons-1-check")
-    reset = selenium_utils_get.driver.find_element_by_id("parsons-1-reset")
-    message = selenium_utils_get.driver.find_element_by_id("parsons-1-message")
+    checkme = selenium_utils_get.driver.find_element(By.ID, "parsons-1-check")
+    reset = selenium_utils_get.driver.find_element(By.ID, "parsons-1-reset")
+    message = selenium_utils_get.driver.find_element(By.ID, "parsons-1-message")
     assert message.get_attribute("style") == "display: none;"
     checkme.click()
     assert message.get_attribute("class") == "alert alert-danger"
     reset.click()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-3"), answer
+        source.find_element(By.ID, "parsons-1-block-3"), answer
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-2"),
-        answer.find_element_by_id("parsons-1-block-3"),
+        source.find_element(By.ID, "parsons-1-block-2"),
+        answer.find_element(By.ID, "parsons-1-block-3"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-1"),
-        answer.find_element_by_id("parsons-1-block-2"),
+        source.find_element(By.ID, "parsons-1-block-1"),
+        answer.find_element(By.ID, "parsons-1-block-2"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-0"),
-        answer.find_element_by_id("parsons-1-block-1"),
+        source.find_element(By.ID, "parsons-1-block-0"),
+        answer.find_element(By.ID, "parsons-1-block-1"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop_by_offset(
-        answer.find_element_by_id("parsons-1-block-0"), -50, 0
+        answer.find_element(By.ID, "parsons-1-block-0"), -50, 0
     ).perform()
     wait_for_animation(selenium_utils_get, "#parsons-1-block-0")
     checkme.click()
-    message = selenium_utils_get.driver.find_element_by_id("parsons-1-message")
+    message = selenium_utils_get.driver.find_element(By.ID, "parsons-1-message")
     assert message.get_attribute("class") == "alert alert-info"
 
     # check that reset works
     reset.click()
-    blocks = source.find_elements_by_class_name("block")
+    blocks = source.find_elements(By.CLASS_NAME, "block")
     assert len(blocks) == 5
 
 
 def test_help(selenium_utils_get):
     selenium_utils_get.wait_until_ready("test_parsons_1")
 
-    source = selenium_utils_get.driver.find_element_by_id("parsons-1-source")
-    answer = selenium_utils_get.driver.find_element_by_id("parsons-1-answer")
-    reset = selenium_utils_get.driver.find_element_by_id("parsons-1-reset")
+    source = selenium_utils_get.driver.find_element(By.ID, "parsons-1-source")
+    answer = selenium_utils_get.driver.find_element(By.ID, "parsons-1-answer")
+    reset = selenium_utils_get.driver.find_element(By.ID, "parsons-1-reset")
     reset.click()
-    checkme = selenium_utils_get.driver.find_element_by_id("parsons-1-check")
+    checkme = selenium_utils_get.driver.find_element(By.ID, "parsons-1-check")
     # click help, should cause pop up
-    helpBtn = selenium_utils_get.driver.find_element_by_id("parsons-1-help")
+    helpBtn = selenium_utils_get.driver.find_element(By.ID, "parsons-1-help")
     helpBtn.click()
     assert wait_and_close_alert(selenium_utils_get)
 
     # try three distinct full attempts => help should cause pop up then cause stuff to happen
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-4"), answer
+        source.find_element(By.ID, "parsons-1-block-4"), answer
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-2"),
-        answer.find_element_by_id("parsons-1-block-4"),
+        source.find_element(By.ID, "parsons-1-block-2"),
+        answer.find_element(By.ID, "parsons-1-block-4"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-1"),
-        answer.find_element_by_id("parsons-1-block-2"),
+        source.find_element(By.ID, "parsons-1-block-1"),
+        answer.find_element(By.ID, "parsons-1-block-2"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-0"),
-        answer.find_element_by_id("parsons-1-block-1"),
-    ).perform()
-    wait_for_animation(selenium_utils_get, "#parsons-1-block-0")
-    checkme.click()
-    reset.click()
-    ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-2"), answer
-    ).perform()
-    ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-4"),
-        answer.find_element_by_id("parsons-1-block-2"),
-    ).perform()
-    ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-1"),
-        answer.find_element_by_id("parsons-1-block-2"),
-    ).perform()
-    ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-0"),
-        answer.find_element_by_id("parsons-1-block-1"),
+        source.find_element(By.ID, "parsons-1-block-0"),
+        answer.find_element(By.ID, "parsons-1-block-1"),
     ).perform()
     wait_for_animation(selenium_utils_get, "#parsons-1-block-0")
     checkme.click()
     reset.click()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-2"), answer
+        source.find_element(By.ID, "parsons-1-block-2"), answer
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-4"),
-        answer.find_element_by_id("parsons-1-block-2"),
+        source.find_element(By.ID, "parsons-1-block-4"),
+        answer.find_element(By.ID, "parsons-1-block-2"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-0"),
-        answer.find_element_by_id("parsons-1-block-4"),
+        source.find_element(By.ID, "parsons-1-block-1"),
+        answer.find_element(By.ID, "parsons-1-block-2"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-1"),
-        answer.find_element_by_id("parsons-1-block-0"),
+        source.find_element(By.ID, "parsons-1-block-0"),
+        answer.find_element(By.ID, "parsons-1-block-1"),
+    ).perform()
+    wait_for_animation(selenium_utils_get, "#parsons-1-block-0")
+    checkme.click()
+    reset.click()
+    ActionChains(selenium_utils_get.driver).drag_and_drop(
+        source.find_element(By.ID, "parsons-1-block-2"), answer
+    ).perform()
+    ActionChains(selenium_utils_get.driver).drag_and_drop(
+        source.find_element(By.ID, "parsons-1-block-4"),
+        answer.find_element(By.ID, "parsons-1-block-2"),
+    ).perform()
+    ActionChains(selenium_utils_get.driver).drag_and_drop(
+        source.find_element(By.ID, "parsons-1-block-0"),
+        answer.find_element(By.ID, "parsons-1-block-4"),
+    ).perform()
+    ActionChains(selenium_utils_get.driver).drag_and_drop(
+        source.find_element(By.ID, "parsons-1-block-1"),
+        answer.find_element(By.ID, "parsons-1-block-0"),
     ).perform()
     wait_for_animation(selenium_utils_get, "#parsons-1-block-1")
     checkme.click()
@@ -130,26 +131,26 @@ def test_help(selenium_utils_get):
     helpBtn.click()  # remove the incorrect block
     assert wait_and_close_alert(selenium_utils_get)
     wait_for_animation(selenium_utils_get, "#parsons-1-block-4")
-    b4 = source.find_element_by_id("parsons-1-block-4")
+    b4 = source.find_element(By.ID, "parsons-1-block-4")
     assert b4.get_attribute("class") == "block disabled"
 
     helpBtn.click()  # Combine blocks
     assert wait_and_close_alert(selenium_utils_get)
     wait_for_animation(selenium_utils_get, "#parsons-1-block-3")
-    l5 = answer.find_element_by_id("parsons-1-line-5")
+    l5 = answer.find_element(By.ID, "parsons-1-line-5")
     # There seems to be a timing issue -- a bit of delay makes this pass.
     time.sleep(0.1)
     assert l5.get_attribute("class") == "prettyprint lang-py"
     try:
-        selenium_utils_get.driver.find_element_by_id("parsons-1-block-3")
+        selenium_utils_get.driver.find_element(By.ID, "parsons-1-block-3")
     except NoSuchElementException:
         pass
     else:
         assert False
-    b2 = answer.find_element_by_id("parsons-1-block-2")
-    l3 = b2.find_element_by_id("parsons-1-line-3")
-    l4 = b2.find_element_by_id("parsons-1-line-4")
-    l5 = b2.find_element_by_id("parsons-1-line-5")
+    b2 = answer.find_element(By.ID, "parsons-1-block-2")
+    l3 = b2.find_element(By.ID, "parsons-1-line-3")
+    l4 = b2.find_element(By.ID, "parsons-1-line-4")
+    l5 = b2.find_element(By.ID, "parsons-1-line-5")
     assert l3
     assert l4
     assert l5
@@ -170,113 +171,113 @@ def test_numbering(selenium_utils_get):
     selenium_utils_get.wait_until_ready("test_parsons_2")
 
     # right label block
-    rlb = selenium_utils_get.driver.find_element_by_id("parsons-2-block-1")
-    assert len(rlb.find_elements_by_class_name("labels")) == 1  # has label
-    assert len(rlb.find_elements_by_class_name("lines")) == 1  # has lines
-    children = rlb.find_elements_by_xpath("*")
+    rlb = selenium_utils_get.driver.find_element(By.ID, "parsons-2-block-1")
+    assert len(rlb.find_elements(By.CLASS_NAME, "labels")) == 1  # has label
+    assert len(rlb.find_elements(By.CLASS_NAME, "lines")) == 1  # has lines
+    children = rlb.find_elements(By.XPATH, "*")
     assert "lines" in children[0].get_attribute("class").split()
     assert "labels" in children[1].get_attribute("class").split()
     # label on right
 
     # left label block
-    llb = selenium_utils_get.driver.find_element_by_id("parsons-3-block-1")
-    assert len(llb.find_elements_by_class_name("labels")) == 1  # has label
-    assert len(llb.find_elements_by_class_name("lines")) == 1  # has lines
-    children = llb.find_elements_by_xpath("*")
+    llb = selenium_utils_get.driver.find_element(By.ID, "parsons-3-block-1")
+    assert len(llb.find_elements(By.CLASS_NAME, "labels")) == 1  # has label
+    assert len(llb.find_elements(By.CLASS_NAME, "lines")) == 1  # has lines
+    children = llb.find_elements(By.XPATH, "*")
     assert "lines" in children[1].get_attribute("class").split()
     assert "labels" in children[0].get_attribute("class").split()
     # label on left
 
     # no label block
-    nlb = selenium_utils_get.driver.find_element_by_id("parsons-4-block-1")
-    assert len(nlb.find_elements_by_class_name("labels")) == 0  # no label
-    assert len(nlb.find_elements_by_class_name("lines")) == 1  # has lines
+    nlb = selenium_utils_get.driver.find_element(By.ID, "parsons-4-block-1")
+    assert len(nlb.find_elements(By.CLASS_NAME, "labels")) == 0  # no label
+    assert len(nlb.find_elements(By.CLASS_NAME, "lines")) == 1  # has lines
 
 
 def test_indentation(selenium_utils_get):
     selenium_utils_get.wait_until_ready("test_parsons_1")
 
-    source = selenium_utils_get.driver.find_element_by_id("parsons-1-source")
-    answer = selenium_utils_get.driver.find_element_by_id("parsons-1-answer")
-    reset = selenium_utils_get.driver.find_element_by_id("parsons-1-reset")
+    source = selenium_utils_get.driver.find_element(By.ID, "parsons-1-source")
+    answer = selenium_utils_get.driver.find_element(By.ID, "parsons-1-answer")
+    reset = selenium_utils_get.driver.find_element(By.ID, "parsons-1-reset")
     reset.click()
-    checkme = selenium_utils_get.driver.find_element_by_id("parsons-1-check")
+    checkme = selenium_utils_get.driver.find_element(By.ID, "parsons-1-check")
 
     # try three distinct full attempts => help should cause pop up then cause stuff to happen
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-4"), answer
+        source.find_element(By.ID, "parsons-1-block-4"), answer
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-2"),
-        answer.find_element_by_id("parsons-1-block-4"),
+        source.find_element(By.ID, "parsons-1-block-2"),
+        answer.find_element(By.ID, "parsons-1-block-4"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-1"),
-        answer.find_element_by_id("parsons-1-block-2"),
+        source.find_element(By.ID, "parsons-1-block-1"),
+        answer.find_element(By.ID, "parsons-1-block-2"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-0"),
-        answer.find_element_by_id("parsons-1-block-1"),
+        source.find_element(By.ID, "parsons-1-block-0"),
+        answer.find_element(By.ID, "parsons-1-block-1"),
     ).perform()
     wait_for_animation(selenium_utils_get, "#parsons-1-block-0")
     checkme.click()
     reset.click()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-2"), answer
+        source.find_element(By.ID, "parsons-1-block-2"), answer
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-4"),
-        answer.find_element_by_id("parsons-1-block-2"),
+        source.find_element(By.ID, "parsons-1-block-4"),
+        answer.find_element(By.ID, "parsons-1-block-2"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-1"),
-        answer.find_element_by_id("parsons-1-block-2"),
+        source.find_element(By.ID, "parsons-1-block-1"),
+        answer.find_element(By.ID, "parsons-1-block-2"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-0"),
-        answer.find_element_by_id("parsons-1-block-1"),
+        source.find_element(By.ID, "parsons-1-block-0"),
+        answer.find_element(By.ID, "parsons-1-block-1"),
     ).perform()
     wait_for_animation(selenium_utils_get, "#parsons-1-block-0")
     checkme.click()
     reset.click()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-3"), answer
+        source.find_element(By.ID, "parsons-1-block-3"), answer
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-2"),
-        answer.find_element_by_id("parsons-1-block-3"),
+        source.find_element(By.ID, "parsons-1-block-2"),
+        answer.find_element(By.ID, "parsons-1-block-3"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-1"),
-        answer.find_element_by_id("parsons-1-block-2"),
+        source.find_element(By.ID, "parsons-1-block-1"),
+        answer.find_element(By.ID, "parsons-1-block-2"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-1-block-0"),
-        answer.find_element_by_id("parsons-1-block-1"),
+        source.find_element(By.ID, "parsons-1-block-0"),
+        answer.find_element(By.ID, "parsons-1-block-1"),
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop_by_offset(
-        answer.find_element_by_id("parsons-1-block-0"), -50, 0
+        answer.find_element(By.ID, "parsons-1-block-0"), -50, 0
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop_by_offset(
-        answer.find_element_by_id("parsons-1-block-1"), -50, 0
+        answer.find_element(By.ID, "parsons-1-block-1"), -50, 0
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop_by_offset(
-        answer.find_element_by_id("parsons-1-block-2"), -50, 0
+        answer.find_element(By.ID, "parsons-1-block-2"), -50, 0
     ).perform()
     ActionChains(selenium_utils_get.driver).drag_and_drop_by_offset(
-        answer.find_element_by_id("parsons-1-block-3"), -50, 0
+        answer.find_element(By.ID, "parsons-1-block-3"), -50, 0
     ).perform()
     wait_for_animation(selenium_utils_get, "#parsons-1-block-3")
     checkme.click()
     assert wait_and_close_alert(selenium_utils_get)
-    b1 = answer.find_element_by_id("parsons-1-block-1")
-    b2 = answer.find_element_by_id("parsons-1-block-2")
-    b3 = answer.find_element_by_id("parsons-1-block-3")
+    b1 = answer.find_element(By.ID, "parsons-1-block-1")
+    b2 = answer.find_element(By.ID, "parsons-1-block-2")
+    b3 = answer.find_element(By.ID, "parsons-1-block-3")
     assert b1.get_attribute("class") == "block indentRight"
     assert b2.get_attribute("class") == "block indentRight"
     assert b3.get_attribute("class") == "block indentRight"
 
-    helpBtn = selenium_utils_get.driver.find_element_by_id("parsons-1-help")
+    helpBtn = selenium_utils_get.driver.find_element(By.ID, "parsons-1-help")
     helpBtn.click()  # Combine blocks
     assert wait_and_close_alert(selenium_utils_get)
     wait_for_animation(selenium_utils_get, "#parsons-1-block-1")
@@ -291,38 +292,37 @@ def test_indentation(selenium_utils_get):
     assert b2.get_attribute("class") == "block indentRight"
     assert b3.get_attribute("class") == "block indentRight"
 
-
 def test_dag_grader(selenium_utils_get):
     selenium_utils_get.wait_until_ready("test_proof_blocks_1")
 
-    source = selenium_utils_get.driver.find_element_by_id("parsons-6-source")
-    answer = selenium_utils_get.driver.find_element_by_id("parsons-6-answer")
-    checkme = selenium_utils_get.driver.find_element_by_id("parsons-6-check")
-    reset = selenium_utils_get.driver.find_element_by_id("parsons-6-reset")
+    source = selenium_utils_get.driver.find_element(By.ID, "parsons-6-source")
+    answer = selenium_utils_get.driver.find_element(By.ID, "parsons-6-answer")
+    checkme = selenium_utils_get.driver.find_element(By.ID, "parsons-6-check")
+    reset = selenium_utils_get.driver.find_element(By.ID, "parsons-6-reset")
 
     def drag_block(block, before_block):
         ActionChains(selenium_utils_get.driver).drag_and_drop(
-            source.find_element_by_id("parsons-6-block-" + str(block)),
-            answer.find_element_by_id("parsons-6-block-" + str(before_block)),
+            source.find_element(By.ID, "parsons-6-block-" + str(block)),
+            answer.find_element(By.ID, "parsons-6-block-" + str(before_block)),
         ).perform()
 
     reset.click()
 
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-6-block-8"), answer
+        source.find_element(By.ID, "parsons-6-block-8"), answer
     ).perform()
 
     for i in range(8, 0, -1):
         drag_block(i - 1, i)
     wait_for_animation(selenium_utils_get, "#parsons-6-block-0")
     checkme.click()
-    message = selenium_utils_get.driver.find_element_by_id("parsons-6-message")
+    message = selenium_utils_get.driver.find_element(By.ID, "parsons-6-message")
     assert message.get_attribute("class") == "alert alert-info"
 
     reset.click()
 
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-6-block-3"), answer
+        source.find_element(By.ID, "parsons-6-block-3"), answer
     ).perform()
     drag_block(7, 3)
     drag_block(6, 7)
@@ -334,13 +334,13 @@ def test_dag_grader(selenium_utils_get):
     drag_block(5, 1)
     wait_for_animation(selenium_utils_get, "#parsons-6-block-5")
     checkme.click()
-    message = selenium_utils_get.driver.find_element_by_id("parsons-6-message")
+    message = selenium_utils_get.driver.find_element(By.ID, "parsons-6-message")
     assert message.get_attribute("class") == "alert alert-danger"
 
     reset.click()
 
     ActionChains(selenium_utils_get.driver).drag_and_drop(
-        source.find_element_by_id("parsons-6-block-8"), answer
+        source.find_element(By.ID, "parsons-6-block-8"), answer
     ).perform()
     drag_block(7, 8)
     drag_block(6, 7)
@@ -352,7 +352,7 @@ def test_dag_grader(selenium_utils_get):
     drag_block(5, 3)
     wait_for_animation(selenium_utils_get, "#parsons-6-block-5")
     checkme.click()
-    message = selenium_utils_get.driver.find_element_by_id("parsons-6-message")
+    message = selenium_utils_get.driver.find_element(By.ID, "parsons-6-message")
     assert message.get_attribute("class") == "alert alert-info"
 
 

--- a/runestone/parsons/test/test_parsons.py
+++ b/runestone/parsons/test/test_parsons.py
@@ -356,6 +356,58 @@ def test_dag_grader(selenium_utils_get):
     assert message.get_attribute("class") == "alert alert-info"
 
 
+def test_dag_grader_indentation(selenium_utils_get):
+    selenium_utils_get.wait_until_ready("test_parsons_dag_indent")
+
+    source = selenium_utils_get.driver.find_element(By.ID, "parsons-7-source")
+    answer = selenium_utils_get.driver.find_element(By.ID, "parsons-7-answer")
+    checkme = selenium_utils_get.driver.find_element(By.ID, "parsons-7-check")
+    reset = selenium_utils_get.driver.find_element(By.ID, "parsons-7-reset")
+
+    def drag_to_answer(blockNum):
+        targetLoc = answer.location
+        block = source.find_element(By.ID, "parsons-7-block-" + str(blockNum))
+        xOffset = answer.location["x"] - block.location["x"] + 1
+        yOffset = answer.location["y"] - block.location["y"] + 1
+        ActionChains(selenium_utils_get.driver).drag_and_drop_by_offset(
+            block, xOffset, yOffset
+        ).perform()
+
+    reset.click()
+
+    for i in range(5, -1, -1):
+        element = source.find_element(By.ID, "parsons-7-block-" + str(i))
+        drag_to_answer(i)
+    checkme.click()
+
+    message = selenium_utils_get.driver.find_element(By.ID, "parsons-7-message")
+    assert "alert-danger" in message.get_attribute("class")
+
+    checkme.click()
+    b1 = answer.find_element(By.ID, "parsons-7-block-1")
+    b2 = answer.find_element(By.ID, "parsons-7-block-2")
+    b4 = answer.find_element(By.ID, "parsons-7-block-4")
+    assert "indentRight" in b1.get_attribute("class")
+    assert "indentRight" in b2.get_attribute("class")
+    assert "indentRight" in b4.get_attribute("class")
+    
+    ActionChains(selenium_utils_get.driver).drag_and_drop_by_offset(
+        answer.find_element(By.ID, "parsons-7-block-1"), 10, 0
+    ).perform()
+    ActionChains(selenium_utils_get.driver).drag_and_drop_by_offset(
+        answer.find_element(By.ID, "parsons-7-block-2"), 60, 0
+    ).perform()
+    ActionChains(selenium_utils_get.driver).drag_and_drop_by_offset(
+        answer.find_element(By.ID, "parsons-7-block-4"), 10, 0
+    ).perform()
+    wait_for_animation(selenium_utils_get, "#parsons-7-block-4")
+
+    checkme.click()
+    assert "indentRight" not in b1.get_attribute("class")
+    assert "indentRight" not in b2.get_attribute("class")
+    assert "indentRight" not in b4.get_attribute("class")
+
+
 def wait_for_animation(selenium_utils, selector):
     while is_element_animated(selenium_utils, selector):
         time.sleep(0.5)


### PR DESCRIPTION
Indentation check code in line based grader assumes strict ordering. Break it into function for DAG grader to override.

DAG grader assumes every block has a tag and uses that to look up proper indentation in the given solution.