### PR TITLE
Make activecode components clean up old errors before displaying new ones

### DIFF
--- a/runestone/activecode/js/activecode_js.js
+++ b/runestone/activecode/js/activecode_js.js
@@ -52,6 +52,9 @@ export default class JSActiveCode extends ActiveCode {
     }
 
     addErrorMessage(err) {
+        // Clear old errors for this box
+        let eContainerId = this.divid + "_errinfo";
+        $("#" + eContainerId).remove();
         // Add the error message
         this.errLastRun = true;
         var errHead = $("<h3>").html("Error");
@@ -59,7 +62,7 @@ export default class JSActiveCode extends ActiveCode {
             document.createElement("div")
         );
         this.eContainer.className = "error alert alert-danger";
-        this.eContainer.id = this.divid + "_errinfo";
+        this.eContainer.id = eContainerId;
         this.eContainer.appendChild(errHead[0]);
         var errText = this.eContainer.appendChild(
             document.createElement("pre")


### PR DESCRIPTION
Currently if a student is working in an activecode area, each attempt to build and run that has errors generates a new error box (each with identical html id) and displays it AFTER any existing error boxes created by previous attempts to build and run.

This deletes existing error boxes before displaying new ones.

An alternate approach would be to keep old errors, but display new errors on top where they are most visible and make it clear that the older boxes may no longer be relevant. I don't see much value in that unless the editor itself had a better sense of history.