### PR TITLE
Fix small bugs in the literate programming question type

### DIFF
--- a/runestone/lp/js/lp.js
+++ b/runestone/lp/js/lp.js
@@ -145,7 +145,7 @@ class LP extends RunestoneBase {
         // Store the answer as a string, since this is what goes in to / comes out from the database. We have to translate this back to a data structure when restoring from the db or local storage.
         let code_snippets = this.textareasToData();
         this.setLocalStorage({
-            answer: JSON.stringify({ code_snippets: code_snippets }),
+            answer: { code_snippets: code_snippets },
             timestamp: new Date(),
         });
         // Store the answer that the server returns, which includes additional data (correct/incorrect, feedback from the build, etc.).
@@ -178,8 +178,6 @@ class LP extends RunestoneBase {
         }
         serverAnswer.answer.code_snippets = code_snippets;
         this.displayAnswer(serverAnswer);
-        // JSON-encode the answer for storage.
-        serverAnswer.answer = JSON.stringify(serverAnswer.answer);
         this.setLocalStorage(serverAnswer);
     }
 
@@ -269,7 +267,10 @@ class LP extends RunestoneBase {
     }
 
     setLocalStorage(data) {
-        localStorage.setItem(this.localStorageKey(), JSON.stringify(data));
+        // Make a shallow copy, so we can JSON-encode the code snippets (matching what comes from the server) without changing the original object.
+        data_clone = object.assign({}, data);
+        data_clone.answer =  JSON.stringify(data.answer);
+        localStorage.setItem(this.localStorageKey(), JSON.stringify(data_clone));
     }
 }
 

--- a/runestone/lp/lp.py
+++ b/runestone/lp/lp.py
@@ -195,7 +195,7 @@ class _LpBuildButtonDirective(RunestoneIdDirective):
     # No optional arguments.
     optional_arguments = 0
     # Per http://docutils.sourceforge.net/docs/howto/rst-directives.html, True if content is allowed. However, this isn't checked or enforced.
-    has_content = True
+    has_content = False
     # Options. Everything but language is currently ignored. This is based on activecode, so in the future similar support would be provided for these options.
     option_spec = RunestoneIdDirective.option_spec.copy()
     option_spec.update(
@@ -232,10 +232,6 @@ class _LpBuildButtonDirective(RunestoneIdDirective):
         lp_node["source"], lp_node["line"] = self.state_machine.get_source_and_line(
             self.lineno
         )
-        # Insert the question number.
-        self.content.append(self.options["qnumber"], "lp")
-        # Parse it, since the number may be a role.
-        self.state.nested_parse(self.content, self.content_offset, lp_node)
 
         return [lp_node]
 


### PR DESCRIPTION
- Avoid including text inside the `lp_build` directive in the resulting output (introduced in 9f751d5c).
- Display code for LP problems when not on the problem's page (e.g. in an assignment, in the instructor grading interface).
- Correct use of local storage to comply with a base class call.
