### PR TITLE
Micro Parsons: Render blocks raw when all blocks are html in non-html problems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "handsontable": "7.2.2",
                 "jexcel": "^3.9.1",
                 "jquery-ui": "1.10.4",
-                "micro-parsons": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.5/micro-parsons-0.1.5.tgz",
+                "micro-parsons": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.6/micro-parsons-0.1.6.tgz",
                 "select2": "^4.1.0-rc.0",
                 "sql.js": "1.5.0",
                 "vega-embed": "3.14.0",
@@ -2715,9 +2715,9 @@
             }
         },
         "node_modules/micro-parsons": {
-            "version": "0.1.5",
-            "resolved": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.5/micro-parsons-0.1.5.tgz",
-            "integrity": "sha512-1Gw34tK3H3pMv1hjHMjincWmiic+iei+wHj0uXScH6lFud6bbohlkfmRt0xaIRm/lO8sC4yrhCfwMSlMah9hpg==",
+            "version": "0.1.6",
+            "resolved": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.6/micro-parsons-0.1.6.tgz",
+            "integrity": "sha512-OEuMXyEnSN6o2rRvHhIkKTuGzwv0zlzJLjtyTF9X7cYgUff7iyH/gwNQmd0WifBw4x2eVs8gv7a/jE2YRERnvQ==",
             "license": "MIT",
             "dependencies": {
                 "highlight.js": "^11.7.0",
@@ -7844,8 +7844,8 @@
             "dev": true
         },
         "micro-parsons": {
-            "version": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.5/micro-parsons-0.1.5.tgz",
-            "integrity": "sha512-1Gw34tK3H3pMv1hjHMjincWmiic+iei+wHj0uXScH6lFud6bbohlkfmRt0xaIRm/lO8sC4yrhCfwMSlMah9hpg==",
+            "version": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.6/micro-parsons-0.1.6.tgz",
+            "integrity": "sha512-OEuMXyEnSN6o2rRvHhIkKTuGzwv0zlzJLjtyTF9X7cYgUff7iyH/gwNQmd0WifBw4x2eVs8gv7a/jE2YRERnvQ==",
             "requires": {
                 "highlight.js": "^11.7.0",
                 "sortablejs": "^1.14.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "handsontable": "7.2.2",
                 "jexcel": "^3.9.1",
                 "jquery-ui": "1.10.4",
-                "micro-parsons": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.4/micro-parsons-0.1.4.tgz",
+                "micro-parsons": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.5/micro-parsons-0.1.5.tgz",
                 "select2": "^4.1.0-rc.0",
                 "sql.js": "1.5.0",
                 "vega-embed": "3.14.0",
@@ -2715,9 +2715,9 @@
             }
         },
         "node_modules/micro-parsons": {
-            "version": "0.1.4",
-            "resolved": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.4/micro-parsons-0.1.4.tgz",
-            "integrity": "sha512-3hg55GJpg779Vhyzk2Ij3Jz/e6UKZGltwpA60EegQrT4C0XR1ioWBoZutNy2BZ5bR6LCC8RXCky4gF9qxl7/ew==",
+            "version": "0.1.5",
+            "resolved": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.5/micro-parsons-0.1.5.tgz",
+            "integrity": "sha512-1Gw34tK3H3pMv1hjHMjincWmiic+iei+wHj0uXScH6lFud6bbohlkfmRt0xaIRm/lO8sC4yrhCfwMSlMah9hpg==",
             "license": "MIT",
             "dependencies": {
                 "highlight.js": "^11.7.0",
@@ -7844,8 +7844,8 @@
             "dev": true
         },
         "micro-parsons": {
-            "version": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.4/micro-parsons-0.1.4.tgz",
-            "integrity": "sha512-3hg55GJpg779Vhyzk2Ij3Jz/e6UKZGltwpA60EegQrT4C0XR1ioWBoZutNy2BZ5bR6LCC8RXCky4gF9qxl7/ew==",
+            "version": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.5/micro-parsons-0.1.5.tgz",
+            "integrity": "sha512-1Gw34tK3H3pMv1hjHMjincWmiic+iei+wHj0uXScH6lFud6bbohlkfmRt0xaIRm/lO8sC4yrhCfwMSlMah9hpg==",
             "requires": {
                 "highlight.js": "^11.7.0",
                 "sortablejs": "^1.14.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "handsontable": "7.2.2",
         "jexcel": "^3.9.1",
         "jquery-ui": "1.10.4",
-        "micro-parsons": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.4/micro-parsons-0.1.4.tgz",
+        "micro-parsons": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.5/micro-parsons-0.1.5.tgz",
         "select2": "^4.1.0-rc.0",
         "sql.js": "1.5.0",
         "vega-embed": "3.14.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "handsontable": "7.2.2",
         "jexcel": "^3.9.1",
         "jquery-ui": "1.10.4",
-        "micro-parsons": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.5/micro-parsons-0.1.5.tgz",
+        "micro-parsons": "https://github.com/amy21206/micro-parsons-element/releases/download/v0.1.6/micro-parsons-0.1.6.tgz",
         "select2": "^4.1.0-rc.0",
         "sql.js": "1.5.0",
         "vega-embed": "3.14.0",

--- a/runestone/hparsons/js/hparsons.js
+++ b/runestone/hparsons/js/hparsons.js
@@ -26,6 +26,7 @@ export default class HParsons extends RunestoneBase {
         this.randomize = $(orig).data("randomize") ? true : false;
         this.isBlockGrading = $(orig).data("blockanswer") ? true : false;
         this.language = $(orig).data("language");
+        this.renderRaw = false;
         if (this.isBlockGrading) {
             this.blockAnswer = $(orig).data("blockanswer").split(" ");
         }
@@ -80,6 +81,22 @@ export default class HParsons extends RunestoneBase {
         this.originalBlocks = this.processSingleContent(code, '--blocks--').split('\n').slice(1,-1);
         this.hiddenSuffix = this.processSingleContent(code, '--hiddensuffix--');
         this.unittest = this.processSingleContent(code, '--unittest--');
+        // (for pretext) if all blocks can be parsed as html but language is not html,
+        //               ask micro parsons to render raw
+        if (this.language != 'html') {
+            this.renderRaw = true;
+            for (let i = 0; i < this.originalBlocks.length; ++i) {
+                if (!this.isHTML(this.originalBlocks[i])) {
+                    this.renderRaw = false;
+                    break;
+                }
+            }
+        }
+    }
+
+    isHTML(block) {
+        let doc = new DOMParser().parseFromString(block, "text/html");
+        return Array.from(doc.body.childNodes).some(node => node.nodeType === 1);
     }
 
     processSingleContent(code, delimitier) {
@@ -116,7 +133,7 @@ export default class HParsons extends RunestoneBase {
             reuse: this.reuse,
             randomize: this.randomize,
             parsonsBlocks: [...this.originalBlocks],
-            language: this.language
+            language: this.renderRaw ? 'raw' : this.language
         }
         InitMicroParsons(props);
         this.hparsonsInput = $(this.outerDiv).find("micro-parsons")[0];

--- a/runestone/hparsons/test/_sources/index.rst
+++ b/runestone/hparsons/test/_sources/index.rst
@@ -171,3 +171,54 @@ Randomized Block with Execution Based Feedback and Hidden Code + error in prefix
     assert 1,1 == final
     assert 1,3 == 90
     assert 3,3 == 99
+
+
+Testing rendering raw blocks (pretext)
+------------------------------------------
+.. hparsons:: test_hparsons_block_raw_render
+    :language: sql
+    :randomize:
+    :blockanswer: 0 1 2 3
+
+    Testing rendering raw blocks.
+
+    Raw blocks will be rendered when:
+
+    1. the langauge is not html
+    
+    2. all blocks contain html nodes
+
+    In this case, it renders html as-is.
+    ~~~~
+    --blocks--
+    SE<b>LECT</b>
+    <code>*</code>
+    FR<span style='color:red;'>OM</span>
+    <h3>test</h3>
+
+
+.. hparsons:: test_hparsons_block_raw_normal
+    :language: sql
+    :randomize:
+    :blockanswer: 0 1 2 3
+
+    Testing rendering raw blocks.
+    
+    Raw blocks will be rendered when:
+
+    1. the langauge is not html
+
+    2. all blocks contain html nodes
+
+    In this case, one of the blocks does not contain html, so it is rendered as code.
+    
+    This is to prevent rendering some html strings as a part of a complete line,
+    
+    e.g. ``a = '<code>abc</code>'`` in python.
+
+    ~~~~
+    --blocks--
+    SELECT
+    <code>*</code>
+    FR<span style='color:red;'>OM</span>
+    <h3>test</h3>


### PR DESCRIPTION
RunestoneInteractive/rs#20 

Render blocks raw when micro Parsons find all blocks contain HTML, and when the language is not html.

Reason for asking all blocks to contain HTML:
a complete HTML can be used as a string in other languages, e.g. in Python, `re.match('<b>', '<b>content</b>')`

Two examples are shown below (included in test).

![image](https://github.com/RunestoneInteractive/RunestoneComponents/assets/25169592/8abca0e1-9b77-4b25-b4a1-1a0f4457e834)

![image](https://github.com/RunestoneInteractive/RunestoneComponents/assets/25169592/7808d3ab-d9be-4dd1-964d-e5daea061359)


micro-Parsons dependency is updated in this PR, so `npm install` is needed.